### PR TITLE
ci: ntfy when a PR lands in prod (opt-out via no-ntfy label)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,3 +40,25 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy dist --project-name=interstellarai-net --branch=${{ github.head_ref || github.ref_name }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify prod landing
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          [ -z "$NTFY_TOPIC" ] && exit 0
+          pr=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number // empty')
+          body="direct push: $(git log -1 --pretty=%s)"
+          if [ -n "$pr" ]; then
+            if gh pr view "$pr" --repo "${{ github.repository }}" --json labels --jq '.labels[].name' | grep -qx 'no-ntfy'; then
+              echo "PR #$pr has no-ntfy label — skipping"
+              exit 0
+            fi
+            title=$(gh pr view "$pr" --repo "${{ github.repository }}" --json title --jq '.title')
+            body="PR #$pr: $title"
+          fi
+          curl -s -o /dev/null \
+            -H "Title: ${{ github.event.repository.name }} landed in prod" \
+            -H "Tags: tada" \
+            -d "$body" "ntfy.sh/$NTFY_TOPIC"


### PR DESCRIPTION
## Summary
- After successful Cloudflare Pages deploy of main, ping ntfy with the PR title.
- Only fires on push to main (not PR previews).
- Opt-out via \`no-ntfy\` label; no-op if \`NTFY_TOPIC\` secret isn't set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)