### PR TITLE
feat: update project list — add Reli + Annie, remove Archon + Beads

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -79,7 +79,8 @@ const path = Astro.url.pathname;
           <div>
             <div class="footer-h">Projects</div>
             <a href="https://filmduel.interstellarai.net" target="_blank" rel="noreferrer">FilmDuel</a>
-            <a href="https://github.com/alexsiri7/Archon" target="_blank" rel="noreferrer">Archon</a>
+            <a href="https://github.com/alexsiri7/Reli" target="_blank" rel="noreferrer">Reli</a>
+            <a href="https://github.com/alexsiri7/word-coach-annie" target="_blank" rel="noreferrer">Annie</a>
             <a href="https://github.com/alexsiri7/un-reminder" target="_blank" rel="noreferrer">un-reminder</a>
             <a href="https://github.com/alexsiri7/cosmic-match" target="_blank" rel="noreferrer">Cosmic Match</a>
           </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ import Layout from "../layouts/Layout.astro";
             <a class="btn btn-link btn-md" href="/tenets">Read the tenets</a>
           </div>
           <div class="hero-meta">
-            <span>◉ 7 repos in orbit</span>
+            <span>◉ 5 repos in orbit</span>
             <span>✶ 4 ADRs, counting</span>
             <span>· auto-deployed</span>
           </div>
@@ -64,22 +64,22 @@ import Layout from "../layouts/Layout.astro";
           <p class="blurb">Rank movies and TV via ELO duels.</p>
           <div class="foot"><span>FastAPI · React</span><span>↗</span></div>
         </a>
-        <div class="pf-card">
+        <a class="pf-card" href="https://github.com/alexsiri7/Reli">
           <div class="row">
             <p class="name">Reli</p>
             <span class="badge badge-wip">wip</span>
           </div>
           <p class="blurb">Personal AI assistant with a knowledge graph.</p>
-          <div class="foot"><span>FastAPI · React</span><span></span></div>
-        </div>
-        <div class="pf-card">
+          <div class="foot"><span>FastAPI · React</span><span>↗</span></div>
+        </a>
+        <a class="pf-card" href="https://github.com/alexsiri7/word-coach-annie">
           <div class="row">
             <p class="name"><em>Word Coach</em> Annie</p>
             <span class="badge badge-wip">wip</span>
           </div>
           <p class="blurb">AI writing assistant for novelists.</p>
-          <div class="foot"><span>Next.js · Supabase</span><span></span></div>
-        </div>
+          <div class="foot"><span>Next.js · Supabase</span><span>↗</span></div>
+        </a>
         <div class="pf-card">
           <div class="row">
             <p class="name"><em>Cosmic</em> Match</p>
@@ -95,22 +95,6 @@ import Layout from "../layouts/Layout.astro";
           </div>
           <p class="blurb">Stochastic, context-aware habit prompts.</p>
           <div class="foot"><span>Android · on-device AI</span><span></span></div>
-        </div>
-        <a class="pf-card" href="https://github.com/alexsiri7/Archon">
-          <div class="row">
-            <p class="name">Archon</p>
-            <span class="badge badge-wip">wip</span>
-          </div>
-          <p class="blurb">Open-source AI coding harness.</p>
-          <div class="foot"><span>TypeScript · YAML</span><span>↗</span></div>
-        </a>
-        <div class="pf-card">
-          <div class="row">
-            <p class="name">Beads</p>
-            <span class="badge badge-wip">wip</span>
-          </div>
-          <p class="blurb">Distributed graph issue tracker for AI agents.</p>
-          <div class="foot"><span>Go · Dolt</span><span></span></div>
         </div>
       </div>
     </div>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -23,18 +23,18 @@ import Layout from "../layouts/Layout.astro";
             <span class="stack">FastAPI · React · Postgres</span>
             <span class="status"><span class="badge badge-live">live</span></span>
           </a>
-          <div class="pf-row">
+          <a class="pf-row" href="https://github.com/alexsiri7/Reli">
             <span class="name">Reli</span>
             <span class="desc">Personal AI assistant with a knowledge graph. Python/FastAPI + React, Postgres with pgvector.</span>
             <span class="stack">FastAPI · React · pgvector</span>
             <span class="status"><span class="badge badge-wip">wip</span></span>
-          </div>
-          <div class="pf-row">
+          </a>
+          <a class="pf-row" href="https://github.com/alexsiri7/word-coach-annie">
             <span class="name"><em>Word Coach</em> Annie</span>
             <span class="desc">AI writing assistant for novelists. Next.js 15, PostgreSQL/Supabase, Prisma, with an MCP server exposing 48 tools.</span>
             <span class="stack">Next.js · Supabase · Prisma</span>
             <span class="status"><span class="badge badge-wip">wip</span></span>
-          </div>
+          </a>
         </div>
       </div>
 
@@ -54,27 +54,6 @@ import Layout from "../layouts/Layout.astro";
             <span class="name">The <em>Un-Reminder</em></span>
             <span class="desc">Stochastic, context-aware habit prompts designed to defeat notification blindness. Native Android, on-device AI, no backend.</span>
             <span class="stack">Android · on-device AI</span>
-            <span class="status"><span class="badge badge-wip">wip</span></span>
-          </div>
-        </div>
-      </div>
-
-      <div class="pf-shape-group">
-        <div class="pf-shape-head">
-          <h2>Tooling</h2>
-          <span class="pf-shape-meta eyebrow">Open source · CLI</span>
-        </div>
-        <div class="pf-list-row">
-          <a class="pf-row" href="https://github.com/alexsiri7/Archon">
-            <span class="name">Archon</span>
-            <span class="desc">Open-source AI coding harness. YAML workflow engine that drives the automation pipeline every other project in this portfolio depends on.</span>
-            <span class="stack">TypeScript · YAML</span>
-            <span class="status"><span class="badge badge-wip">wip</span></span>
-          </a>
-          <div class="pf-row">
-            <span class="name">Beads</span>
-            <span class="desc">Distributed graph issue tracker for AI agents. Go + Dolt.</span>
-            <span class="stack">Go · Dolt</span>
             <span class="status"><span class="badge badge-wip">wip</span></span>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Removed Archon and Beads from the project list on the home page and /projects page — these are third-party dev tools, not the user's own projects.
- Added Reli and Word Coach Annie as linked entries on both pages (they were already present as unlinked placeholders on /projects; promoted to `<a>` with GitHub links). Links point to GitHub repos until public sites go live.
- Updated footer project list in `Layout.astro`: swapped Archon for Reli and Annie.
- Adjusted hero-meta "7 repos in orbit" → "5 repos in orbit" to match the new count.
- Removed the now-empty "Tooling" shape-group section from /projects.

## Test plan

- [x] `npm run build` succeeds
- [x] `dist/index.html` and `dist/projects/index.html` contain Reli / Word Coach Annie
- [x] `dist/index.html` and `dist/projects/index.html` no longer contain Archon / Beads as project entries
- [ ] Cloudflare Pages preview renders correctly

Note: ADR-004 ("Archon drives automation") is left untouched — it's a decision-log entry about tooling, not a project listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)