### PR TITLE
fix: point Reli + Annie to their subdomains

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -79,8 +79,8 @@ const path = Astro.url.pathname;
           <div>
             <div class="footer-h">Projects</div>
             <a href="https://filmduel.interstellarai.net" target="_blank" rel="noreferrer">FilmDuel</a>
-            <a href="https://github.com/alexsiri7/Reli" target="_blank" rel="noreferrer">Reli</a>
-            <a href="https://github.com/alexsiri7/word-coach-annie" target="_blank" rel="noreferrer">Annie</a>
+            <a href="https://reli.interstellarai.net" target="_blank" rel="noreferrer">Reli</a>
+            <a href="https://annie.interstellarai.net" target="_blank" rel="noreferrer">Annie</a>
             <a href="https://github.com/alexsiri7/un-reminder" target="_blank" rel="noreferrer">un-reminder</a>
             <a href="https://github.com/alexsiri7/cosmic-match" target="_blank" rel="noreferrer">Cosmic Match</a>
           </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,7 +64,7 @@ import Layout from "../layouts/Layout.astro";
           <p class="blurb">Rank movies and TV via ELO duels.</p>
           <div class="foot"><span>FastAPI · React</span><span>↗</span></div>
         </a>
-        <a class="pf-card" href="https://github.com/alexsiri7/Reli">
+        <a class="pf-card" href="https://reli.interstellarai.net">
           <div class="row">
             <p class="name">Reli</p>
             <span class="badge badge-wip">wip</span>
@@ -72,7 +72,7 @@ import Layout from "../layouts/Layout.astro";
           <p class="blurb">Personal AI assistant with a knowledge graph.</p>
           <div class="foot"><span>FastAPI · React</span><span>↗</span></div>
         </a>
-        <a class="pf-card" href="https://github.com/alexsiri7/word-coach-annie">
+        <a class="pf-card" href="https://annie.interstellarai.net">
           <div class="row">
             <p class="name"><em>Word Coach</em> Annie</p>
             <span class="badge badge-wip">wip</span>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -23,13 +23,13 @@ import Layout from "../layouts/Layout.astro";
             <span class="stack">FastAPI · React · Postgres</span>
             <span class="status"><span class="badge badge-live">live</span></span>
           </a>
-          <a class="pf-row" href="https://github.com/alexsiri7/Reli">
+          <a class="pf-row" href="https://reli.interstellarai.net">
             <span class="name">Reli</span>
             <span class="desc">Personal AI assistant with a knowledge graph. Python/FastAPI + React, Postgres with pgvector.</span>
             <span class="stack">FastAPI · React · pgvector</span>
             <span class="status"><span class="badge badge-wip">wip</span></span>
           </a>
-          <a class="pf-row" href="https://github.com/alexsiri7/word-coach-annie">
+          <a class="pf-row" href="https://annie.interstellarai.net">
             <span class="name"><em>Word Coach</em> Annie</span>
             <span class="desc">AI writing assistant for novelists. Next.js 15, PostgreSQL/Supabase, Prisma, with an MCP server exposing 48 tools.</span>
             <span class="stack">Next.js · Supabase · Prisma</span>


### PR DESCRIPTION
## Summary
- PR #5 pointed Reli/Annie entries at GitHub repos, but the site's convention is `<app>.interstellarai.net` (see FilmDuel).
- Repoint both to `https://reli.interstellarai.net` and `https://annie.interstellarai.net` across footer, home, and projects pages.
- Both subdomains already respond via HTTPS.

## Test plan
- [x] `npm run build` succeeds
- [x] Built HTML on `/` and `/projects/` shows new subdomain URLs
- [x] No residual `github.com/alexsiri7/(Reli|word-coach-annie)` occurrences in `src/` or `dist/`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>