### PR TITLE
feat: add favicon.svg (use nav-brand mark)

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  
+  <ellipse cx="32" cy="32" rx="26" ry="10" transform="rotate(-24 32 32)" stroke="#1A1A1A" stroke-width="2.5" fill="none"></ellipse>
+  <circle cx="32" cy="32" r="6" fill="#D97757"></circle>
+  <circle cx="52" cy="22" r="2.5" fill="#1A1A1A"></circle>
+</svg>


### PR DESCRIPTION
## Summary
- Copy `public/assets/logo-mark.svg` → `public/favicon.svg` so the `<link rel="icon">` in `Layout.astro:15` resolves instead of 404'ing.
- Favicon matches the nav-brand identity (orbit + coral dot + satellite).

## Test plan
- [x] Astro build succeeds locally
- [ ] After merge: hard-refresh the tab, favicon appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)