### PR TITLE
feat: add global coding + documentation conventions

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -12,4 +12,14 @@ const decisions = defineCollection({
   }),
 });
 
-export const collections = { decisions };
+const conventions = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    order: z.number(),
+    summary: z.string(),
+    updated: z.coerce.date(),
+  }),
+});
+
+export const collections = { decisions, conventions };

--- a/src/content/conventions/clean-code.md
+++ b/src/content/conventions/clean-code.md
@@ -1,0 +1,115 @@
+---
+title: Clean code
+order: 1
+summary: Principles for code humans and AI agents can keep reading. Small functions, honest names, one level of abstraction, and the discipline to leave duplication alone until it earns its abstraction.
+updated: 2026-04-18
+---
+
+## Why this exists
+
+Code is read far more often than it is written. In a portfolio where agents draft most PRs and humans review them, the cost of a confusing function is paid every time another agent tries to extend it. These principles are the shared baseline the PR review agent uses, and the vocabulary humans use to push back when the agent is wrong.
+
+The goal is not purity. The goal is code that a tired human and a cold-start agent can both understand in one pass.
+
+## Single Responsibility Principle
+
+**Rule**: a class or function has one reason to change.
+
+Describe what it does in one sentence. If you need `and` or `or`, you have two responsibilities fused together. A `UserService` that loads users, formats user profiles, and sends welcome emails has three reasons to change; the email templating team, the database team, and the profile UI team all edit the same file and step on each other.
+
+The test is not "how many methods does it have" but "who is the customer". One module per customer.
+
+## Single Level of Abstraction
+
+**Rule**: a function mixes at most one level of abstraction.
+
+Don't interleave business logic with I/O. Don't mix policy with mechanism. A function that decides *what* to charge a customer should not also know *how* to serialise JSON over HTTP to Stripe. If you read a function top-to-bottom and the reading speed changes — "high-level, high-level, oh now we're parsing a header" — you've mixed levels.
+
+```
+# mixed levels — bad
+def checkout(cart):
+    total = sum(item.price for item in cart.items)
+    if cart.coupon:
+        total *= (1 - cart.coupon.discount)
+    resp = requests.post("https://api.stripe.com/charges",
+                        json={"amount": int(total * 100)},
+                        headers={"Authorization": f"Bearer {os.environ['STRIPE_KEY']}"})
+    resp.raise_for_status()
+    return resp.json()["id"]
+
+# one level — good
+def checkout(cart):
+    total = price_after_discount(cart)
+    return payments.charge(total, currency=cart.currency)
+```
+
+The rewritten `checkout` reads like a specification. The HTTP plumbing is in `payments.charge`, where it can be tested and swapped without touching checkout logic.
+
+## Small functions
+
+**Rule**: aim for functions that fit on a screen. Roughly 20 lines is a soft target.
+
+This is not a religion. A 25-line function that reads top-to-bottom in one thought is fine. A 12-line function with four nested conditionals is not. The target exists because large functions almost always hide a missing abstraction — a loop body that wants to be its own function, a two-step algorithm pretending to be one step.
+
+When you find yourself scrolling to see the end of a function, ask: "what would I call the middle of this?" If you can name it, extract it.
+
+## Naming
+
+**Rule**: nouns for things, verbs for actions, meaningful over clever.
+
+Bad names force the reader to decode. `data`, `info`, `manager`, `util`, `helper`, `doStuff`, `process`, `handle` tell the reader nothing. Long, specific names beat short, vague ones every time: `days_since_last_login` beats `delta`. `cancel_pending_subscriptions` beats `cleanup`.
+
+Banned without explicit justification: `Util`, `Utils`, `Manager`, `Helper`, `Service` as a generic suffix, `do*`, `handle*`, `process*`. If you reach for one of these you have not yet understood what the thing does. Understand it, then name it.
+
+The exception is established idioms in the language or framework — `RequestHandler` in a web framework is fine; it's a term of art, not a dodge.
+
+## DRY, with nuance
+
+**Rule**: wait for the third instance before abstracting.
+
+Two functions that look similar are not always the same thing. Two invoice-generation paths that share five lines of formatting may diverge next month when one gets VAT and the other gets sales tax. A premature abstraction couples them together; future edits now need to thread parameters through an abstraction nobody wanted.
+
+The rule of three (Fowler): duplicate the code twice. On the third occurrence, extract. By then you know which parts are truly the same and which just happened to look alike.
+
+Premature deduplication is worse than duplication, because duplication is visible and abstractions hide.
+
+## Comments
+
+**Rule**: comments explain the WHY, not the WHAT.
+
+If a comment describes what the code does, the code is unclear — rewrite the code. `// increment counter` above `counter += 1` is noise. `// retry budget: the upstream rate-limits at 10/s and we need to stay under` is signal.
+
+Good comments explain:
+
+- non-obvious constraints (`// must be sorted — binary search below`),
+- workarounds for bugs in other systems (`// Chrome 120 returns wrong mime-type for blob URLs`),
+- security-critical invariants (`// this must run inside the auth check; do not move above`),
+- references (`// algorithm from Knuth 4A §7.2.1.6, exercise 36`).
+
+Comments that lie are worse than no comments. If the code changed and the comment didn't, delete the comment.
+
+## Error handling
+
+**Rule**: fail fast at boundaries, be specific about recovery, never swallow silently.
+
+At the boundary of your code (HTTP handler, job consumer, CLI entry point), validate aggressively and reject bad input with a clear error. Inside your code, trust your types — don't pepper defensive checks through every function.
+
+When you catch an exception, either handle it with intent (retry, fallback, transform into a domain error) or re-raise with added context. `except Exception: pass` and `catch (e) { console.log(e) }` are how systems corrupt state quietly. If you don't know what to do with an error, let it propagate.
+
+Exceptions are for exceptional cases. Expected conditions — "user not found", "out of stock" — belong in return types, not throws.
+
+## State and mutability
+
+**Rule**: minimise mutable state. Prefer pure functions where possible.
+
+Shared mutable state is the most common source of bugs in every non-trivial system. A function that takes inputs and returns outputs is testable, cacheable, and composes cleanly. A function that reads and writes a global, a singleton, or an argument by reference has a hidden contract with the whole program.
+
+You cannot eliminate state — databases, files, and users exist. You can push it to the edges: a thin I/O shell around a pure core. The pure core is where bugs are cheap to find.
+
+## References
+
+- Robert C. Martin, *Clean Code* (2008). The Single Responsibility and Single Level of Abstraction rules come from here.
+- John Ousterhout, *A Philosophy of Software Design* (2018). Chapter 2 ("The Nature of Complexity") and Chapter 4 ("Modules Should Be Deep") are the other half of this document; Ousterhout disagrees with Martin on function size, and both are worth reading.
+- Martin Fowler, *Refactoring* (2nd ed., 2018). The rule of three, naming, and "extract function" are from here.
+- Kent Beck, *Tidy First?* (2023). On when to refactor; short and correct.
+- Dijkstra, *A Discipline of Programming* (1976). On state and invariants; old but still ahead of most new books.

--- a/src/content/conventions/documentation.md
+++ b/src/content/conventions/documentation.md
@@ -1,0 +1,81 @@
+---
+title: Documentation
+order: 2
+summary: Every app has a README, every tech decision has an ADR, every external dependency is documented, and stale docs are deleted on sight. Reading the code is not documentation.
+updated: 2026-04-18
+---
+
+## Why this exists
+
+Documentation is a promise to your future self and to every agent or engineer who touches the repo after you. "Read the code to understand" is a failure mode dressed up as humility — it forces every reader to re-derive the mental model you already have. The portfolio ships too fast for that.
+
+These rules are the minimum. The PR review agent enforces them; a PR that adds a new service without a README, or a new external dependency without a documented integration point, is flagged.
+
+## Every app has a README
+
+**Rule**: every repository has a `README.md` at the root that any reader can use to understand and run the project.
+
+The README answers three questions in 2–3 short paragraphs:
+
+1. **What does this app do?** One paragraph. Plain language, not marketing. "FilmDuel is a web app that ranks movies and TV shows using ELO duels. Users pick a winner between two titles and the system updates the ratings."
+2. **Who is it for?** One or two sentences about the intended user and the kind of problem they bring. Without this, contributors build the wrong thing.
+3. **How do I run it locally?** Concrete commands, from a clean clone: install dependencies, set environment variables, start the dev server, run the tests. If there are prerequisites (Postgres running, Node 20, a `.env.local` with specific keys), name them.
+
+"See the docs" is not an answer. The README is the door; if the door is locked, nobody gets in.
+
+## Major tech decisions are ADRs
+
+**Rule**: any decision that shapes architecture, data, or the team's daily workflow is recorded as an Architecture Decision Record in MADR format.
+
+ADRs live under `docs/adr/` in each repo, numbered sequentially, never renumbered. Each ADR has:
+
+- **Context**: what forced the decision. Constraints, prior state, the problem in the reader's language.
+- **Decision**: what we are doing, in the imperative. Not "we might consider", but "we will".
+- **Alternatives considered**: the options we rejected and why. An ADR without rejected alternatives is a press release.
+- **Consequences**: what this costs us. Trade-offs, new risks, things we now can't do.
+
+ADRs are immutable. If the decision changes, write a new ADR that supersedes the old one, and mark the old one `superseded`. Nobody is embarrassed by an ADR that turned out wrong; they are embarrassed by decisions made without one.
+
+The bar for "major" is lower than you think. If a future engineer would reasonably ask "why did we pick this?", write the ADR.
+
+## Architecture overview in one file
+
+**Rule**: the shape of the system is discoverable in a single file.
+
+Either the README has an Architecture section, or there is a `docs/architecture.md`. It answers: what are the services, how do they talk to each other, where does the data live, what runs in CI, where does it deploy. A simple ASCII diagram beats a 40-page Confluence page nobody maintains.
+
+"It's in the commit history" is not discoverable. "Ask the team" is not discoverable. If a new contributor (human or agent) cannot answer "what are the moving parts?" in ten minutes of reading, the overview is missing.
+
+## External integrations are documented
+
+**Rule**: every external service the app depends on has its own section explaining why it's there, what it does, and how to replace it.
+
+For each of: auth provider, CDN, payment processor, email service, analytics, AI provider, managed database, feature-flag service — the docs name:
+
+- **Why this service**: the concrete requirement it solves (not "best-in-class", actual reasons).
+- **What it does for us**: which code paths call it, which data goes through it.
+- **How to replace it**: the interface we depend on, the seams that make swapping possible, and the migration work required.
+
+This matters for three reasons: vendors die, prices change, and data-residency requirements appear. A repo where Stripe is wired into forty files with no documentation is a repo held hostage to Stripe.
+
+## Stale docs are worse than no docs
+
+**Rule**: if a doc lies, delete it.
+
+A wrong README sends every reader in the wrong direction with false confidence. A missing README makes them read the code, which is at least truthful. Delete the lie. Replace it when you have time.
+
+This applies to:
+
+- READMEs that reference commands that no longer work,
+- architecture diagrams that show services we retired,
+- comments that describe the previous implementation,
+- ADRs that were superseded but never marked as such.
+
+The PR review agent is empowered to flag a PR that changes behaviour without updating the corresponding docs, or to flag docs that contradict the code they describe. This is not pedantry; a document that claims to be current and isn't is a trap.
+
+## References
+
+- Michael Nygard, ["Documenting Architecture Decisions"](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) (2011). The original ADR post.
+- [MADR: Markdown Architectural Decision Records](https://adr.github.io/madr/). The format we use.
+- Daniele Procida, ["What nobody tells you about documentation"](https://documentation.divio.com/). The four-quadrant model (tutorials, how-to, reference, explanation) that shapes how to split up long-form docs.
+- Will Larson, *An Elegant Puzzle* (2019), on why documentation decays and what to do about it.

--- a/src/content/conventions/git.md
+++ b/src/content/conventions/git.md
@@ -1,0 +1,109 @@
+---
+title: Git and pull requests
+order: 4
+summary: Small PRs, imperative commit messages that explain the why, one logical change per branch, squash on merge, and nothing destructive on shared history.
+updated: 2026-04-18
+---
+
+## Why this exists
+
+The git history is documentation that writes itself, if you let it. A clean history lets any reader — human or agent — answer "why was this done?" by running `git log` and `git blame`. A messy history buries that answer under merge noise and WIP commits.
+
+These conventions are the ones that hold up across every mainstream team. They're not unique; they are the baseline. The PR review agent enforces them so reviewers can spend their time on substance.
+
+## Commit messages
+
+**Rule**: imperative mood, sentence case, a short subject, a blank line, then a body that explains the why.
+
+The subject line describes what this commit *does to the tree*, in the same voice git itself uses: `add retry budget to stripe client`, not `added` or `adds`. Soft cap of 50 characters so `git log --oneline` reads. Hard cap around 72.
+
+The body explains the WHY. Not "I changed X to Y" — the diff already says that. The body says: what problem forced this change, what alternatives you considered, what future readers should know to avoid undoing it.
+
+```
+add retry budget to stripe client
+
+Stripe rate-limits at 10 rps per account and our checkout burst
+pushes through that window during flash sales. Before this change
+we'd 429 on ~3% of charges and return a generic error to the user.
+
+Retries are capped at 3 with exponential backoff, matching Stripe's
+own recommendation. Beyond that we surface the rate-limit as a
+domain error so the UI can show "please try again" rather than a
+stack trace.
+```
+
+Body lines wrap around 72 characters so they render well in terminals and PR views. Tooling preserves the blank line between subject and body; don't fight it.
+
+## One logical change per PR
+
+**Rule**: a PR does one thing. If the title needs `and`, split.
+
+A PR that "adds the retry budget and fixes the login-page typo and bumps the node version" cannot be reviewed carefully. Reviewers either rubber-stamp the combined diff or nitpick one part while the risky part slides through. If you catch yourself reaching for `and` in the title, open a second PR.
+
+Split rules that usually hold:
+
+- Refactors and behaviour changes go in separate PRs. Refactor first, behaviour second, so each is reviewable.
+- Dependency bumps and feature work don't share a PR. A renovate-style bump is reviewed differently from a feature.
+- "While I was in there" fixes belong in their own small PR, not smuggled in with a big one.
+
+## Keep PRs small
+
+**Rule**: target under 400 changed lines. Alarm over 800.
+
+The research is unambiguous: review quality drops sharply above 400 lines. Reviewers either skim or rubber-stamp. At 800+ lines, bugs are roughly twice as likely to slip through, and reviewers stop leaving substantive comments. This matters more in a pipeline where an AI agent drafts the PR and a human is the last filter.
+
+"Small" counts the changes that carry risk. A generated lockfile or a vendored directory doesn't count; a 600-line refactor across fifteen files does. If a PR is growing past 800 substantive lines, stop and split it — even if that means a stack of dependent PRs.
+
+If a change genuinely cannot be split (large generated migration, single-commit vendor drop), say so in the PR description and point the reviewer at the parts that need human judgement.
+
+## Branching and merging
+
+**Rule**: feature branches off `main`, squash-merge on completion.
+
+Squash-merging keeps `main` linear and makes every commit on `main` correspond to one reviewed PR. `git log --oneline main` reads like a changelog. `git revert` works cleanly because each commit is one logical change. `git bisect` finds regressions fast because each step is atomic.
+
+Preserve history on release branches and long-lived integration branches — those need the full context of how they got there. Short-lived feature branches don't.
+
+Never rebase a branch another person (or agent) is actively working on. Rebasing shared history destroys their work and there's no good recovery. If you need to incorporate `main`, merge it in, or ask the other author to pause first.
+
+## Never force-push shared branches
+
+**Rule**: `--force-with-lease` only on branches you own. Never on shared branches. Never, ever on `main` or release branches.
+
+A force-push to a shared branch rewrites everyone else's history, orphans their in-flight work, and breaks CI pipelines that assumed a stable ref. `--force-with-lease` is slightly safer than `--force` because it refuses when the remote moved under you, but it's still a footgun on shared branches.
+
+On your own feature branch, force-pushing to tidy commits before review is fine. After review starts, prefer additive commits; reviewers shouldn't have to re-review from scratch because you rebased.
+
+## PR titles
+
+**Rule**: conventional-commits style as a prefix, lightly applied.
+
+```
+feat: add retry budget to stripe client
+fix: return 404 when user is deleted mid-request
+chore: bump node to 20.11
+docs: document the staging gate in readme
+refactor: extract pricing rules into separate module
+test: add integration test for coupon expiry
+ci: cache npm install between jobs
+```
+
+These prefixes make the history skimmable and let the PR review agent route PRs to the right review depth — a `docs:` PR doesn't need the same scrutiny as a `feat:`. Don't be militant about the tag if a change spans two categories; pick the dominant one. Don't invent new prefixes.
+
+The title after the prefix follows the same rules as a commit subject: imperative, sentence case, under ~60 characters.
+
+## Safe operations only by default
+
+**Rule**: treat these as off-limits unless a human explicitly approves: `git push --force`, `git reset --hard` on someone else's work, `git branch -D` on shared branches, skipping hooks (`--no-verify`), bypassing signing.
+
+Hooks exist because the team agreed on a check. Skipping a hook because it's inconvenient silently moves the team's floor down. If a hook is wrong, fix the hook; don't bypass it.
+
+Signing likewise. If commits aren't signing, fix the signing setup rather than turning it off.
+
+## References
+
+- Linus Torvalds / git project, ["SubmittingPatches"](https://git-scm.com/docs/SubmittingPatches). The source of the imperative-mood commit subject convention.
+- Tim Pope, ["A Note About Git Commit Messages"](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) (2008). The 50/72 character rule.
+- Google, ["Modern Code Review: A Case Study at Google"](https://sback.it/publications/icse2018seip.pdf). Empirical basis for PR-size limits.
+- Smart Bear, ["Best Kept Secrets of Peer Code Review"](https://smartbear.com/learn/code-review/). The 400-line defect-density study.
+- [Conventional Commits](https://www.conventionalcommits.org/). The prefix style, used lightly.

--- a/src/content/conventions/testing.md
+++ b/src/content/conventions/testing.md
@@ -1,0 +1,89 @@
+---
+title: Testing
+order: 3
+summary: Integration tests over unit tests with heavy mocks. Test behaviour, not lines. Mock the edges, not code you own. Flaky tests are bugs, not weather.
+updated: 2026-04-18
+---
+
+## Why this exists
+
+Tests exist to let us change code without fear. A test suite that slows us down, lies about what the system does, or can't be trusted to fail for real reasons is worse than no suite at all. These conventions favour tests that catch real regressions over tests that decorate the coverage report.
+
+## Integration tests over unit tests with heavy mocking
+
+**Rule**: prefer tests that exercise real collaborators — real database, real HTTP to a local server, real filesystem in a temp directory — over unit tests that stub everything.
+
+Mocks lie when reality changes. A unit test that mocks the database returns whatever you told it to return, which is exactly what the code-under-test expects, which is why the test passes. The same code against a real database finds the foreign-key violation, the off-by-one in the query, the implicit transaction that was missing. A fast integration test with a real Postgres in a container beats a bank of unit tests with stubs.
+
+"Integration" here does not mean "end-to-end in prod". It means: real instances of things you control, at the smallest scope that exercises the contract. `testcontainers` for a database, a local HTTP server for an API client, a temp directory for a file-writer. Spin them up per-test-suite and tear them down; don't share state across tests.
+
+This does not eliminate unit tests. It sets the default: integration first, unit where integration would be clumsy or slow.
+
+## Unit test pure functions and complex logic
+
+**Rule**: unit tests earn their keep on pure functions and on genuinely intricate branching logic.
+
+A pricing calculator with twelve rules for VAT, coupons, and partial refunds wants exhaustive unit tests — one per rule, fast, pure, independent. A string formatter wants a table of input/output pairs. A parser wants a catalogue of malformed inputs.
+
+Framework glue — controllers that wire a request to a service, Lambda handlers that parse an event and call one function — does not want unit tests. Those tests exercise mocks and indirection; they fail whenever you rename a field. Cover that layer with an integration test that actually hits the endpoint.
+
+## Tests read as specifications
+
+**Rule**: a test name tells the reader what the system does, in plain language.
+
+`test_user_can_cancel_subscription_before_renewal` is a specification. `test_cancel_1` is noise. When a test fails, the name should tell a triaging reader what behaviour broke, without opening the test body.
+
+Conventions that work:
+
+- `it("returns 404 when the user does not exist")` — behaviour-driven style.
+- `test_renewal_charges_full_price_when_coupon_has_expired` — snake case with the same structure.
+- `Given_a_paid_user_When_cancelling_Then_subscription_ends_at_period_end` — Given/When/Then when a test covers several moving pieces.
+
+Pick one style per repo and hold it. Don't mix.
+
+## Coverage is a symptom, not a goal
+
+**Rule**: track coverage as a signal. Don't target a number.
+
+100% line coverage can be achieved by exercising every line without asserting anything. 60% line coverage can represent a rigorously-tested core with untested UI glue. The number alone tells you nothing.
+
+What to look at instead:
+
+- **Behaviour coverage**: do the important user journeys have a test? Can you delete a core feature and have a test fail?
+- **Branch coverage on pure logic**: are the decision points in your pricing / auth / parsing code exercised with representative inputs?
+- **Mutation testing** (e.g. Stryker, mutmut) when you really want to know the suite is honest: it changes an operator in the source and fails if your tests don't notice.
+
+A PR that moves line coverage from 78% to 79% is not evidence of improvement. A PR that adds a test which would have caught the last production bug is.
+
+## Mock the edges, not the code you own
+
+**Rule**: mock things across a process or network boundary. Don't mock your own classes.
+
+Good mocks: the Stripe client, the clock (`datetime.now`), the filesystem in tests where it would be slow, a third-party AI provider. These are edges — things you don't control, can't afford to hit, or that introduce flakiness.
+
+Bad mocks: your own `UserRepository`, your own `InvoiceCalculator`, your own `EmailTemplateRenderer`. Mocking your own code couples the test to the current implementation. Any refactor that changes the internal wiring breaks the tests without any behaviour changing — the worst kind of test: expensive to maintain, no signal when it fails.
+
+If a collaborator is hard to use in a test because of side effects, fix the design. Make it take a dependency you can substitute at the edge. Don't paper over the design with mocks.
+
+## Flaky tests are bugs
+
+**Rule**: a test that flakes twice is quarantined the same day and fixed that week. Never `@Ignore` and forget.
+
+A flaky test trains the team to re-run CI until it passes, which trains the team to ignore real failures. The suite loses its signal and becomes a ritual.
+
+When a test flakes:
+
+1. Reproduce it. Run it 100 times locally, or in CI with a retry loop. If it flakes, the race is real.
+2. Name the race. Async with no await? Time-of-day dependency? Order-dependent state? Test pollution from a previous test?
+3. Fix it at the cause. Replace wall-clock time with an injectable clock. Reset the database between tests. Await the actual condition, not a `sleep(100)`.
+4. If you cannot fix it today, delete it. A missing test is honest. A lying test is not.
+
+Retry mechanisms (`--retries 3`) are an anaesthetic, not a cure. Use them only while you're actively fixing the flake, never as a permanent setting.
+
+## References
+
+- Martin Fowler, ["Mocks Aren't Stubs"](https://martinfowler.com/articles/mocksArentStubs.html) (2007, updated). The classic argument for why over-mocking lies.
+- Kent Beck, *Test-Driven Development: By Example* (2002). Still the clearest short book on how tests drive design.
+- Gerard Meszaros, *xUnit Test Patterns* (2007). The taxonomy for fakes, stubs, mocks, spies, and fixtures.
+- Google Testing Blog, ["Flaky Tests at Google and How We Mitigate Them"](https://testing.googleblog.com/2016/05/flaky-tests-at-google-and-how-we.html). Data from a very large suite.
+- Dave Farley, *Modern Software Engineering* (2021). On deterministic tests as a prerequisite for continuous delivery.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,6 +37,7 @@ const path = Astro.url.pathname;
           <a class={`nav-link ${path === '/' ? 'is-active' : ''}`} href="/">Home</a>
           <a class={`nav-link ${path.startsWith('/tenets') ? 'is-active' : ''}`} href="/tenets">Tenets</a>
           <a class={`nav-link ${path.startsWith('/decisions') ? 'is-active' : ''}`} href="/decisions">Decisions</a>
+          <a class={`nav-link ${path.startsWith('/conventions') ? 'is-active' : ''}`} href="/conventions">Conventions</a>
           <a class={`nav-link ${path.startsWith('/projects') ? 'is-active' : ''}`} href="/projects">Projects</a>
         </div>
         <details class="nav-mobile">
@@ -45,6 +46,7 @@ const path = Astro.url.pathname;
             <a href="/">Home</a>
             <a href="/tenets">Tenets</a>
             <a href="/decisions">Decisions</a>
+            <a href="/conventions">Conventions</a>
             <a href="/projects">Projects</a>
           </div>
         </details>
@@ -74,6 +76,7 @@ const path = Astro.url.pathname;
             <div class="footer-h">Handbook</div>
             <a href="/tenets">Tenets</a>
             <a href="/decisions">Decision log</a>
+            <a href="/conventions">Conventions</a>
             <a href="/projects">Projects</a>
           </div>
           <div>

--- a/src/pages/conventions/[slug].astro
+++ b/src/pages/conventions/[slug].astro
@@ -1,0 +1,45 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { getCollection } from "astro:content";
+
+export async function getStaticPaths() {
+  const conventions = await getCollection("conventions");
+  return conventions.map((c) => ({ params: { slug: c.slug }, props: { convention: c } }));
+}
+
+const { convention } = Astro.props;
+const { Content } = await convention.render();
+---
+
+<Layout title={`${convention.data.title} · Conventions · InterStellar AI`}>
+  <section class="adr-head">
+    <div class="wrap-prose">
+      <div class="crumbs"><a href="/conventions">← all conventions</a></div>
+      <h1>{convention.data.title}</h1>
+      <div class="adr-meta">
+        <span><strong>Type</strong>: convention</span>
+        <span><strong>Updated</strong>: {convention.data.updated.toISOString().slice(0, 10)}</span>
+      </div>
+      <p class="convention-lede">{convention.data.summary}</p>
+    </div>
+  </section>
+  <section class="adr-body">
+    <div class="wrap-prose">
+      <Content />
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .convention-lede {
+    font-size: 17px;
+    line-height: 1.6;
+    color: var(--ink-2);
+    max-width: 65ch;
+    margin: var(--sp-4) 0 0;
+    text-wrap: pretty;
+  }
+  :global(html[data-dir="b"]) .convention-lede {
+    color: #C6BFAE;
+  }
+</style>

--- a/src/pages/conventions/index.astro
+++ b/src/pages/conventions/index.astro
@@ -1,0 +1,74 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { getCollection } from "astro:content";
+
+const conventions = (await getCollection("conventions")).sort(
+  (a, b) => a.data.order - b.data.order
+);
+---
+
+<Layout title="Conventions · InterStellar AI">
+  <section class="pf-hero">
+    <div class="wrap-prose">
+      <h1>Conventions</h1>
+      <p class="lede">Opinionated engineering conventions shared across every project in the portfolio. Humans read them here; the PR review agent fetches the raw markdown from GitHub. Same source of truth for both.</p>
+    </div>
+  </section>
+  <section class="adr-body">
+    <div class="wrap-prose">
+      <div class="decisions">
+        {conventions.map((c) => (
+          <a class="dec" href={`/conventions/${c.slug}`}>
+            <span class="num">{String(c.data.order).padStart(2, "0")}</span>
+            <span class="title">{c.data.title}</span>
+            <span class="meta-date">{c.data.updated.toISOString().slice(0, 10)}</span>
+            <span class="meta-status">
+              <span class="badge badge-neutral">convention</span>
+            </span>
+          </a>
+        ))}
+      </div>
+      <div class="convention-summaries">
+        {conventions.map((c) => (
+          <div class="convention-summary">
+            <h3><a href={`/conventions/${c.slug}`}>{c.data.title}</a></h3>
+            <p>{c.data.summary}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .convention-summaries {
+    margin-top: var(--sp-8);
+    display: grid;
+    gap: var(--sp-6);
+  }
+  .convention-summary h3 {
+    font-family: var(--font-display);
+    font-size: 24px;
+    line-height: 1.2;
+    margin: 0 0 var(--sp-2);
+    font-weight: 400;
+    letter-spacing: -0.005em;
+  }
+  .convention-summary h3 a {
+    color: inherit;
+    text-decoration: none;
+  }
+  .convention-summary h3 a:hover {
+    color: var(--terracotta);
+  }
+  .convention-summary p {
+    font-size: 16px;
+    line-height: 1.65;
+    color: var(--ink-2);
+    margin: 0;
+    text-wrap: pretty;
+  }
+  :global(html[data-dir="b"]) .convention-summary p {
+    color: #C6BFAE;
+  }
+</style>


### PR DESCRIPTION
## Summary

Adds a new page group at `/conventions/` alongside the existing `tenets`, `decisions`, and `projects`. Four opinionated-but-sourced markdown docs: `clean-code`, `documentation`, `testing`, `git`.

These are the global portfolio conventions, one source of truth for two consumers:

1. **Humans** read them at `interstellarai.net/conventions/<slug>/`.
2. **The PR review agent** (separate work) fetches the raw markdown from GitHub at `src/content/conventions/*.md`.

That lets the agent reason from the same rules humans read, and means when the rules evolve there is exactly one file to update.

## What is in each doc

- **clean-code.md** — SRP, single level of abstraction, small functions as a soft target, naming (with a banned-suffix list), DRY with rule-of-three, comments for WHY only, fail-fast error handling, minimise mutability. References Martin, Ousterhout, Fowler, Beck.
- **documentation.md** — every app has a README, every major decision is a MADR-format ADR, architecture discoverable in one file, external integrations documented with swap-out paths, stale docs deleted. References Nygard, MADR, Divio quadrant model, Larson.
- **testing.md** — integration tests over heavy mocking, unit tests for pure logic and complex branching, tests read as specs, coverage is a symptom not a goal, mock the edges not code you own, flaky tests are bugs not weather. References Fowler, Beck, Meszaros, Google Testing blog, Farley.
- **git.md** — imperative commit subjects + why-in-body, one logical change per PR, <400 lines target, squash-merge feature branches, no force-push on shared branches, conventional-commits-lite prefixes. References git SubmittingPatches, Tim Pope, Google code-review paper, Smart Bear data, Conventional Commits.

## Wiring

- `src/content/config.ts` — new `conventions` collection (title, order, summary, updated).
- `src/pages/conventions/index.astro` — listing page modelled on `decisions/index.astro`.
- `src/pages/conventions/[slug].astro` — detail page modelled on `decisions/[slug].astro`.
- `src/layouts/Layout.astro` — "Conventions" link added to desktop nav, mobile menu, and footer handbook column.

No changes to existing tenets or decisions content.

## Test plan

- [x] `npm run build` passes locally; 13 pages built including `/conventions/` and `/conventions/{clean-code,documentation,testing,git}/`.
- [x] Spot-checked generated HTML in `dist/conventions/` — all four pages render and contain expected headings.
- [x] Nav + footer updated in layout, verified "Conventions" link appears on the built home page.
- [ ] Cloudflare Pages deploy goes green on this PR's preview URL.
- [ ] After merge, live site `interstellarai.net/conventions/` renders the new pages.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>