### PR TITLE
ops: add cron scripts (moved from gt/mayor/scripts)

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -41,6 +41,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: workers/feedback
           secrets: |
-            GITHUB_FEEDBACK_TOKEN
+            FEEDBACK_TOKEN
         env:
-          GITHUB_FEEDBACK_TOKEN: ${{ secrets.GITHUB_FEEDBACK_TOKEN }}
+          FEEDBACK_TOKEN: ${{ secrets.FEEDBACK_TOKEN }}

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,46 @@
+name: Deploy feedback worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "workers/feedback/**"
+      - ".github/workflows/deploy-worker.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: worker-feedback
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: workers/feedback
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: workers/feedback
+          secrets: |
+            GITHUB_FEEDBACK_TOKEN
+        env:
+          GITHUB_FEEDBACK_TOKEN: ${{ secrets.GITHUB_FEEDBACK_TOKEN }}

--- a/ops/cron/.gitignore
+++ b/ops/cron/.gitignore
@@ -1,0 +1,7 @@
+# Logs (runtime-only, should live in /tmp or /var/log, never in-tree)
+*.log
+*.log.*
+
+# Any accidental secrets drop
+secrets.env
+*.creds.txt

--- a/ops/cron/README.md
+++ b/ops/cron/README.md
@@ -1,0 +1,53 @@
+# ops/cron
+
+Scheduled scripts that run the archon pipeline on this machine:
+- pick up new GitHub issues and dispatch archon
+- keep PRs merging (rebase/fix/auto-merge)
+- review PRs via archon-smart-pr-review
+- watch pipeline health (CI red, zombie runs, disk pressure)
+- daily release tags
+- Supabase DB backups
+- APK auto-sync to connected Android devices
+
+## Secrets
+
+Secrets are **never** committed here. Scripts load them from:
+
+```
+$ARCHON_CRON_SECRETS   (default: ~/.config/archon-cron/secrets.env, chmod 600)
+```
+
+Required keys (see individual scripts for which ones each uses):
+
+- `ANNIE_DB_URL`, `RELI_DB_URL`, `FILMDUEL_DB_URL` — Supabase connection strings used by `backup-dbs.sh`.
+- `NTFY_TOPIC` — private ntfy.sh topic for notifications. No fallback default; scripts fail loud if missing.
+
+Set perms: `chmod 600 ~/.config/archon-cron/secrets.env`.
+
+## Install the crontab
+
+The file `crontab` in this directory is a committed reference. To install:
+
+```
+crontab ops/cron/crontab
+```
+
+It installs with absolute paths pointing at `/mnt/ext-fast/interstellarai.net/ops/cron/...`. Adjust paths there if this repo lives elsewhere on your machine.
+
+## Script index
+
+| Script | Cadence | What it does |
+|---|---|---|
+| `issue-pickup-cron.sh` | every 15 min | auto-label new issues, fire `archon-fix-github-issue` on oldest queued |
+| `pr-review-cron.sh` | every 5 min | fire `archon-smart-pr-review` on open non-draft PRs, once per (repo, pr, sha) |
+| `pipeline-health-cron.sh` | every 30 min | main-CI-red detection, zombie-run reaping, disk pressure, stall detection |
+| `backup-dbs.sh` | every 3h (at :17) | Supabase → local + rclone to Google Drive |
+| `daily-release-cron.sh` | 08:00 daily | tag + release per repo if main moved since last release |
+| `auto-apk-sync.sh` | every 5 min | pull latest signed APK from CI, install to any connected device |
+| `apk-autosync-daemon.sh` | systemd user service | event-driven counterpart to `auto-apk-sync.sh` |
+| `fetch-apks.sh` / `install-apks.sh` | manual | helper CLIs for APK ops |
+| `generate-android-keystore.sh` | manual, one-off per project | generate release keystore + upload to GH Actions secrets |
+| `lib/archon-projects.sh` | sourced by others | loads project list from `archon-projects.txt` |
+| `archon-projects.txt` | data | canonical list of managed project slugs under `alexsiri7/` |
+
+Note: `pr-maintenance-cron.sh` lives separately in the `archon` repo (`/mnt/ext-fast/archon/scripts/`). It's in the installed crontab but not versioned here.

--- a/ops/cron/apk-autosync-daemon.sh
+++ b/ops/cron/apk-autosync-daemon.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# apk-autosync-daemon.sh — event-driven companion to auto-apk-sync.sh.
+# Streams `adb track-devices` and invokes the sync script the moment a
+# device transitions to `device` state (fully authorised / ready). Sends
+# a ntfy notification summarising what was installed / skipped / failed.
+#
+# One-line usage:
+#   status:  systemctl --user status apk-autosync.service
+#   logs:    journalctl --user -u apk-autosync.service -f   (or tail -f /tmp/apk-autosync-daemon.log)
+#   stop:    systemctl --user stop apk-autosync.service
+#   restart: systemctl --user restart apk-autosync.service
+#   disable: systemctl --user disable --now apk-autosync.service
+#
+# ntfy topic is read from $NTFY_TOPIC in $ARCHON_CRON_SECRETS (default
+# ~/.config/archon-cron/secrets.env). Missing → fails loud; no guessable fallback.
+#
+# The 5-min cron (`auto-apk-sync.sh`) is still the belt-and-braces fallback.
+
+set -euo pipefail
+
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYNC_SCRIPT="$SCRIPT_DIR/auto-apk-sync.sh"
+LOG_FILE="/tmp/apk-autosync-daemon.log"
+SYNC_LOG="/tmp/apk-sync.log"
+LOG_PREFIX="[apk-autosync-daemon]"
+DEBOUNCE_SECONDS=60
+
+# NTFY_TOPIC loaded from secrets.env (see ops/cron/README.md). Fail loud if unset
+# — falling back to a guessable default would let anyone publish to this topic.
+SECRETS_FILE="${ARCHON_CRON_SECRETS:-$HOME/.config/archon-cron/secrets.env}"
+# shellcheck source=/dev/null
+[ -r "$SECRETS_FILE" ] && . "$SECRETS_FILE"
+: "${NTFY_TOPIC:?NTFY_TOPIC not set — populate $SECRETS_FILE}"
+# Base URL for ntfy — override with NTFY_BASE_URL for local testing.
+NTFY_BASE_URL="${NTFY_BASE_URL:-https://ntfy.sh}"
+
+log() {
+  local line
+  line="$(date -Is) $LOG_PREFIX $*"
+  echo "$line"
+  echo "$line" >> "$LOG_FILE"
+}
+
+notify() {
+  local title="$1" msg="$2" priority="${3:-default}" tags="${4:-iphone}"
+  curl -s -o /dev/null \
+    -H "Title: $title" -H "Priority: $priority" -H "Tags: $tags" \
+    -d "$msg" "$NTFY_BASE_URL/$NTFY_TOPIC" 2>/dev/null || true
+}
+
+# Debounce table: serial → epoch of last run.
+declare -A LAST_RUN
+
+# Parse `auto-apk-sync.sh` output for a specific serial and build a
+# human-friendly multi-line body. Echoes the body; sets global
+# PRIORITY=default|high based on whether any install failed.
+PRIORITY="default"
+summarise_run() {
+  local serial="$1" run_log="$2"
+  PRIORITY="default"
+
+  # Only lines matching this serial (ignore other devices).
+  # Looking for `installed`, `install failed`, or implicit "skipped" when
+  # the state file already records the current SHA (no install/skip line).
+  local body=""
+  local -A STATUS      # project -> status string
+  local -A SHA_NOW     # project -> installed sha
+  local -A SHA_PREV    # project -> previous sha
+
+  while IFS= read -r line; do
+    # e.g. `... [apk-sync] cosmic-match: installing cosmic-match-26a4bdb.apk on 41110DLJG000P5 (prev=cosmic-match-d723d44.apk)`
+    if [[ "$line" =~ \[apk-sync\]\ ([a-z-]+):\ installing\ [a-z-]+-([0-9a-f]+)\.apk\ on\ ${serial}\ \(prev=([^\)]*)\) ]]; then
+      local proj="${BASH_REMATCH[1]}" sha="${BASH_REMATCH[2]}" prev="${BASH_REMATCH[3]}"
+      # Strip filename wrapper from prev -> keep just the sha (or empty).
+      if [[ "$prev" =~ -([0-9a-f]+)\.apk$ ]]; then
+        prev="${BASH_REMATCH[1]}"
+      fi
+      SHA_NOW[$proj]="$sha"
+      SHA_PREV[$proj]="$prev"
+      STATUS[$proj]="installing"
+      continue
+    fi
+    # e.g. `... [apk-sync] cosmic-match: installed cosmic-match-26a4bdb.apk on 41110DLJG000P5`
+    if [[ "$line" =~ \[apk-sync\]\ ([a-z-]+):\ installed\ [a-z-]+-([0-9a-f]+)\.apk\ on\ ${serial}$ ]]; then
+      local proj="${BASH_REMATCH[1]}"
+      STATUS[$proj]="installed"
+      continue
+    fi
+    # e.g. `... [apk-sync] cosmic-match: install failed on 41110DLJG000P5 — <msg>`
+    if [[ "$line" =~ \[apk-sync\]\ ([a-z-]+):\ install\ failed\ on\ ${serial} ]]; then
+      local proj="${BASH_REMATCH[1]}"
+      STATUS[$proj]="failed"
+      PRIORITY="high"
+      continue
+    fi
+  done < "$run_log"
+
+  # Also pick up "skipped — already installed" for projects that didn't
+  # appear in installing lines. Read current symlinks + state files.
+  local projects=(cosmic-match un-reminder)
+  for proj in "${projects[@]}"; do
+    if [ -z "${STATUS[$proj]:-}" ]; then
+      local link="$HOME/apks/${proj}-latest.apk"
+      local state_file="$HOME/.apk-sync-state/${serial}-${proj}.sha"
+      if [ -e "$link" ] && [ -f "$state_file" ]; then
+        local cur prev
+        cur=$(readlink "$link")
+        prev=$(cat "$state_file")
+        if [ "$cur" = "$prev" ] && [[ "$cur" =~ -([0-9a-f]+)\.apk$ ]]; then
+          SHA_NOW[$proj]="${BASH_REMATCH[1]}"
+          STATUS[$proj]="skipped"
+        fi
+      fi
+    fi
+  done
+
+  # Build body lines in a stable order.
+  for proj in "${projects[@]}"; do
+    local st="${STATUS[$proj]:-unknown}"
+    local sha="${SHA_NOW[$proj]:-?}"
+    local prev="${SHA_PREV[$proj]:-}"
+    case "$st" in
+      installed)
+        if [ -n "$prev" ]; then
+          body+="${proj}: ${sha} (installed, was ${prev})"$'\n'
+        else
+          body+="${proj}: ${sha} (installed, fresh)"$'\n'
+        fi
+        ;;
+      skipped)
+        body+="${proj}: ${sha} (skipped — already installed)"$'\n'
+        ;;
+      installing)
+        body+="${proj}: ${sha} (install started — no completion line)"$'\n'
+        PRIORITY="high"
+        ;;
+      failed)
+        body+="${proj}: install failed"$'\n'
+        ;;
+      unknown)
+        body+="${proj}: no state (APK not yet fetched?)"$'\n'
+        ;;
+    esac
+  done
+
+  # Trim trailing newline.
+  printf '%s' "${body%$'\n'}"
+}
+
+run_sync_for_device() {
+  local serial="$1"
+  log "device $serial attached; triggering sync"
+  local run_log
+  run_log=$(mktemp /tmp/apk-autosync-run.XXXXXX)
+
+  # Execute the existing cron script. Tee its output into the tmp file AND
+  # the shared /tmp/apk-sync.log so the normal log history is preserved.
+  if "$SYNC_SCRIPT" 2>&1 | tee -a "$SYNC_LOG" > "$run_log"; then
+    local body
+    body=$(summarise_run "$serial" "$run_log")
+    log "sync completed for $serial; priority=$PRIORITY"
+    notify "📱 Phone synced" "$body" "$PRIORITY"
+  else
+    local rc=$?
+    log "sync script exited non-zero (rc=$rc) for $serial"
+    local tail_lines
+    tail_lines=$(tail -n 10 "$run_log" 2>/dev/null || echo "(no output)")
+    notify "📱 Phone sync FAILED" "auto-apk-sync.sh exited rc=$rc"$'\n\n'"$tail_lines" "high" "warning"
+  fi
+
+  rm -f "$run_log"
+}
+
+log "daemon starting (ntfy topic=$NTFY_TOPIC, debounce=${DEBOUNCE_SECONDS}s)"
+
+# Ensure adb server is up so track-devices doesn't race with a cold start.
+adb start-server >/dev/null 2>&1 || true
+
+# `adb track-devices` streams binary-framed records: a 4-char hex length
+# prefix followed by `<serial>\t<state>\n` (multiple serials separated by
+# newlines within one record). We track each serial's last-seen state so
+# we only fire on transitions into `device`.
+declare -A DEVICE_STATE
+
+# Read adb track-devices one framed record at a time. bash's builtin
+# `read` is line-oriented and would strip the newlines in the payload,
+# so we read exact byte counts from stdin's fd 0 using `head -c`.
+# Note: `head -c` on stdin consumes exactly N bytes and stops — this is
+# what we want. The parent `stdbuf -o0 adb track-devices | ...` pipes
+# keep the stream alive.
+process_stream() {
+  local hex n payload
+  while hex=$(head -c 4); do
+    [ -z "$hex" ] && break
+    [ "${#hex}" -lt 4 ] && break
+    if [[ ! "$hex" =~ ^[0-9a-fA-F]{4}$ ]]; then
+      log "stream desync: got non-hex prefix '$hex' — bailing"
+      return 1
+    fi
+    n=$((16#$hex))
+    if [ "$n" -gt 0 ]; then
+      payload=$(head -c "$n")
+    else
+      payload=""
+    fi
+    handle_record "$payload"
+  done
+}
+
+handle_record() {
+  local payload="$1"
+  # Empty payload means "no devices".
+  if [ -z "$payload" ]; then
+    # Mark all known devices as offline.
+    for s in "${!DEVICE_STATE[@]}"; do
+      if [ "${DEVICE_STATE[$s]}" != "offline" ]; then
+        log "device $s removed"
+        DEVICE_STATE[$s]="offline"
+      fi
+    done
+    return
+  fi
+  # Build set of serials present in this record.
+  declare -A SEEN=()
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    local serial state
+    serial="${line%%$'\t'*}"
+    state="${line#*$'\t'}"
+    SEEN[$serial]=1
+    local prev="${DEVICE_STATE[$serial]:-absent}"
+    if [ "$prev" != "$state" ]; then
+      log "device $serial: $prev -> $state"
+      DEVICE_STATE[$serial]="$state"
+      if [ "$state" = "device" ] && [ "$prev" != "device" ]; then
+        # Debounce in the parent so state survives across the fork.
+        local now last delta
+        now=$(date +%s)
+        last="${LAST_RUN[$serial]:-0}"
+        delta=$((now - last))
+        if [ "$last" -gt 0 ] && [ "$delta" -lt "$DEBOUNCE_SECONDS" ]; then
+          log "device $serial reconnected after ${delta}s — debounced (threshold ${DEBOUNCE_SECONDS}s), skipping"
+        else
+          LAST_RUN[$serial]="$now"
+          # Fire async so we don't block the stream reader.
+          ( run_sync_for_device "$serial" ) &
+        fi
+      fi
+    fi
+  done <<< "$payload"
+  # Any serial we previously knew about that isn't in this record is gone.
+  for s in "${!DEVICE_STATE[@]}"; do
+    if [ -z "${SEEN[$s]:-}" ] && [ "${DEVICE_STATE[$s]}" != "offline" ]; then
+      log "device $s removed"
+      DEVICE_STATE[$s]="offline"
+    fi
+  done
+}
+
+# Trap SIGTERM cleanly.
+trap 'log "daemon received signal, exiting"; exit 0' TERM INT
+
+# Run the stream. adb track-devices writes binary framing, so disable
+# buffering where possible and read it as a byte stream.
+stdbuf -o0 adb track-devices 2>>"$LOG_FILE" | process_stream
+
+# If we reach here, the stream ended — systemd will restart us.
+log "adb track-devices stream ended; exiting to let systemd restart"
+exit 1

--- a/ops/cron/archon-projects.txt
+++ b/ops/cron/archon-projects.txt
@@ -1,0 +1,8 @@
+# Shared list of archon-managed project slugs under alexsiri7/.
+# Read by all pipeline cron scripts. Edit this to add/remove projects.
+un-reminder
+cosmic-match
+word-coach-annie
+filmduel
+reli
+interstellarai.net

--- a/ops/cron/auto-apk-sync.sh
+++ b/ops/cron/auto-apk-sync.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# auto-apk-sync.sh — every tick: pull the latest signed APK per project from
+# the repo's CI, and install it on any connected Android device that's still
+# running an older build.
+#
+# Installs use `adb install -r -d` — preserves app data; only works if
+# signatures match (which they do, because CI uses our real keystore).
+#
+# Per-(project, device) state lives in ~/.apk-sync-state/<serial>-<project>.sha
+# so the same APK is installed at most once per device.
+#
+# Crontab:
+#   */5 * * * * <repo>/ops/cron/auto-apk-sync.sh >> /tmp/apk-sync.log 2>&1
+
+set -uo pipefail
+
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+# Projects to sync: project-name → "owner/repo:workflow:artifact-pattern"
+# Artifact-pattern matches the real-keystore APK artifact name prefix.
+declare -A PROJECTS
+PROJECTS[un-reminder]="alexsiri7/un-reminder:Release:app-release-"
+PROJECTS[cosmic-match]="alexsiri7/cosmic-match:CI:release-apk"
+
+APK_DIR="$HOME/apks"
+STATE_DIR="$HOME/.apk-sync-state"
+LOG_PREFIX="[apk-sync]"
+
+mkdir -p "$APK_DIR" "$STATE_DIR"
+
+log() { echo "$(date -Is) $LOG_PREFIX $*"; }
+
+# Fetch latest successful APK on main for one project. Writes to
+# $APK_DIR/<project>-<sha>.apk and updates $APK_DIR/<project>-latest.apk.
+# Returns 0 on change, 1 on no-op, 2 on error.
+fetch_one() {
+  local project="$1" repo="$2" workflow="$3" artifact_prefix="$4"
+  local run_info run_id sha
+  run_info=$(gh run list --repo "$repo" --workflow "$workflow" \
+    --branch main --status success --limit 1 \
+    --json databaseId,headSha 2>/dev/null) || return 2
+  run_id=$(echo "$run_info" | jq -r '.[0].databaseId // empty')
+  sha=$(echo "$run_info"   | jq -r '.[0].headSha // empty' | cut -c1-7)
+  [ -z "$run_id" ] && return 2
+
+  local dst="$APK_DIR/${project}-${sha}.apk"
+  local link="$APK_DIR/${project}-latest.apk"
+  # Fast path: same SHA already pointed to → no download.
+  if [ -e "$link" ] && [ "$(readlink "$link")" = "$(basename "$dst")" ] && [ -s "$dst" ]; then
+    return 1
+  fi
+
+  local artifacts artifact_name
+  artifacts=$(gh api "repos/$repo/actions/runs/$run_id/artifacts" \
+    --jq '.artifacts[] | select(.expired == false) | .name' 2>/dev/null) || return 2
+  artifact_name=$(echo "$artifacts" | grep -E "^${artifact_prefix}" | grep -v "ci-throwaway" | head -n1)
+  [ -z "$artifact_name" ] && return 2
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  if ! gh run download "$run_id" --repo "$repo" --name "$artifact_name" --dir "$tmpdir" >/dev/null 2>&1; then
+    rm -rf "$tmpdir"
+    return 2
+  fi
+  local src_apk
+  src_apk=$(find "$tmpdir" -name '*.apk' -print -quit)
+  if [ -z "$src_apk" ]; then
+    rm -rf "$tmpdir"
+    return 2
+  fi
+  mv -f "$src_apk" "$dst"
+  ln -sf "$(basename "$dst")" "$link"
+  rm -rf "$tmpdir"
+  log "$project: fetched $sha (run $run_id)"
+  return 0
+}
+
+# Locate an aapt binary (prefers highest build-tools version). Empty if none.
+find_aapt() {
+  local sdk="${ANDROID_HOME:-$HOME/Android/Sdk}"
+  local bt="$sdk/build-tools"
+  [ -d "$bt" ] || { command -v aapt 2>/dev/null; return; }
+  local latest
+  latest=$(ls -1 "$bt" 2>/dev/null | sort -V | tail -n1)
+  [ -n "$latest" ] || return
+  if [ -x "$bt/$latest/aapt" ]; then
+    echo "$bt/$latest/aapt"
+  elif [ -x "$bt/$latest/aapt2" ]; then
+    echo "$bt/$latest/aapt2"
+  else
+    command -v aapt 2>/dev/null
+  fi
+}
+
+# Extract the android package name from an APK. Echoes the name or empty.
+get_pkg_name() {
+  local apk="$1" aapt pkg
+  aapt=$(find_aapt)
+  [ -z "$aapt" ] && return 1
+  pkg=$("$aapt" dump badging "$apk" 2>/dev/null | awk -F"'" '/^package: name=/{print $2; exit}')
+  [ -n "$pkg" ] && echo "$pkg"
+}
+
+# Sanity-check the adb channel for a device; retries once after a short sleep.
+adb_channel_ready() {
+  local serial="$1"
+  if adb -s "$serial" shell echo ready >/dev/null 2>&1; then
+    return 0
+  fi
+  sleep 2
+  adb -s "$serial" shell echo ready >/dev/null 2>&1
+}
+
+# Classify adb install stderr: echoes one of sig_mismatch|parse|transient.
+classify_install_err() {
+  local out="$1"
+  if [[ "$out" == *INSTALL_FAILED_UPDATE_INCOMPATIBLE* ]]; then
+    echo "sig_mismatch"
+  elif [[ "$out" == *INSTALL_PARSE_FAILED* || "$out" == *INSTALL_FAILED_INVALID_APK* ]]; then
+    echo "parse"
+  else
+    echo "transient"
+  fi
+}
+
+# Compare local "latest" symlink against recorded install state per device;
+# if different, adb install -r. Retries transient failures; auto-uninstalls
+# on signature mismatch.
+install_if_new() {
+  local project="$1" serial="$2"
+  local link="$APK_DIR/${project}-latest.apk"
+  [ -e "$link" ] || return 0
+  local cur
+  cur=$(readlink "$link")
+  local state_file="$STATE_DIR/${serial}-${project}.sha"
+  local prev=""
+  [ -f "$state_file" ] && prev=$(cat "$state_file")
+  if [ "$cur" = "$prev" ]; then
+    return 0
+  fi
+
+  # Stabilisation: brief sleep + adb channel recheck.
+  sleep 1
+  if ! adb_channel_ready "$serial"; then
+    log "$project: adb channel not ready on $serial — skipping this tick"
+    return 1
+  fi
+
+  # Emit the canonical "installing" line (daemon regex depends on this exact shape).
+  log "$project: installing $cur on $serial (prev=$prev)"
+
+  local max_attempts=3 attempt=1 out cls rc=1
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if [ "$attempt" -gt 1 ]; then
+      adb -s "$serial" wait-for-device >/dev/null 2>&1 &
+      local wpid=$!
+      ( sleep 5; kill "$wpid" 2>/dev/null ) >/dev/null 2>&1 &
+      wait "$wpid" 2>/dev/null
+      log "$project: installing (retry $attempt/$max_attempts) $cur on $serial"
+    fi
+
+    if out=$(adb -s "$serial" install -r -d "$link" 2>&1); then
+      echo "$cur" > "$state_file"
+      log "$project: installed $cur on $serial"
+      return 0
+    fi
+
+    cls=$(classify_install_err "$out")
+    case "$cls" in
+      sig_mismatch)
+        local pkg=""
+        pkg=$(get_pkg_name "$link" || true)
+        if [ -z "$pkg" ]; then
+          log "$project: sig mismatch on $serial but could not derive package name — aborting"
+          log "$project: install failed on $serial — $out"
+          return 1
+        fi
+        log "$project: sig mismatch on $serial — uninstalling $pkg and retrying"
+        adb -s "$serial" uninstall "$pkg" >/dev/null 2>&1 || true
+        if out=$(adb -s "$serial" install -r -d "$link" 2>&1); then
+          echo "$cur" > "$state_file"
+          log "$project: installed $cur on $serial"
+          return 0
+        fi
+        log "$project: install failed on $serial — $out"
+        return 1
+        ;;
+      parse)
+        log "$project: install failed on $serial — $out"
+        return 1
+        ;;
+      transient)
+        if [ "$attempt" -ge "$max_attempts" ]; then
+          log "$project: install failed on $serial — $out"
+          return 1
+        fi
+        # Backoff: 2s before retry 2, 5s before retry 3.
+        if [ "$attempt" -eq 1 ]; then sleep 2; else sleep 5; fi
+        ;;
+    esac
+    attempt=$((attempt + 1))
+  done
+  return $rc
+}
+
+# ----------------------------------------------------------------------------
+# 1. Fetch latest APKs for every project.
+for project in "${!PROJECTS[@]}"; do
+  IFS=':' read -r repo workflow artifact_prefix <<<"${PROJECTS[$project]}"
+  fetch_one "$project" "$repo" "$workflow" "$artifact_prefix"
+done
+
+# 2. Install to any connected devices.
+mapfile -t DEVICES < <(adb devices 2>/dev/null | awk 'NR>1 && $2=="device" {print $1}')
+if [ "${#DEVICES[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+for serial in "${DEVICES[@]}"; do
+  for project in "${!PROJECTS[@]}"; do
+    install_if_new "$project" "$serial"
+  done
+done

--- a/ops/cron/backup-dbs.sh
+++ b/ops/cron/backup-dbs.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Backup Annie (Supabase PostgreSQL → SQLite) and Reli (SQLite)
+# - Local: /mnt/steam-slow/backups/ (7-day rotation)
+# - Remote: Google Drive via rclone (if configured)
+
+set -euo pipefail
+
+# Secrets: ANNIE_DB_URL, RELI_DB_URL, FILMDUEL_DB_URL loaded from an env file
+# outside the repo. chmod 600 recommended. Override with $ARCHON_CRON_SECRETS.
+SECRETS_FILE="${ARCHON_CRON_SECRETS:-$HOME/.config/archon-cron/secrets.env}"
+# shellcheck source=/dev/null
+[ -r "$SECRETS_FILE" ] && . "$SECRETS_FILE"
+: "${ANNIE_DB_URL:?ANNIE_DB_URL not set — populate $SECRETS_FILE}"
+: "${RELI_DB_URL:?RELI_DB_URL not set — populate $SECRETS_FILE}"
+: "${FILMDUEL_DB_URL:?FILMDUEL_DB_URL not set — populate $SECRETS_FILE}"
+
+BACKUP_ROOT="/mnt/steam-slow/backups"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+KEEP_DAYS=7
+RCLONE_REMOTE="gdrive:backups/gas-town"
+LOG_TAG="[db-backup]"
+
+log() { echo "$LOG_TAG $(date '+%Y-%m-%d %H:%M:%S') $*"; }
+
+# --- Annie (Supabase PostgreSQL → SQLite export) ---
+ANNIE_PROJECT_DIR="/mnt/ext-fast/gc/rigs/annie"
+ANNIE_BACKUP_DIR="$BACKUP_ROOT/annie"
+mkdir -p "$ANNIE_BACKUP_DIR"
+
+ANNIE_OUT="$ANNIE_BACKUP_DIR/word-coach-annie-${TIMESTAMP}.db"
+if cd "$ANNIE_PROJECT_DIR" && DATABASE_URL="$ANNIE_DB_URL" node scripts/export-to-sqlite.mjs "$ANNIE_OUT" 2>&1; then
+    SIZE=$(du -h "$ANNIE_OUT" | cut -f1)
+    PROJECTS=$(sqlite3 "$ANNIE_OUT" "SELECT count(*) FROM Project" 2>/dev/null || echo "?")
+    log "Annie backed up: $ANNIE_OUT ($SIZE, $PROJECTS projects)"
+    if [ "$PROJECTS" = "0" ]; then
+        log "WARNING: Annie backup has 0 projects — possible data loss!"
+    fi
+else
+    log "ERROR: Annie Supabase export failed"
+fi
+
+# --- Reli (Supabase PostgreSQL → SQLite export) ---
+RELI_BACKUP_DIR="$BACKUP_ROOT/reli"
+mkdir -p "$RELI_BACKUP_DIR"
+
+RELI_OUT="$RELI_BACKUP_DIR/reli-${TIMESTAMP}.db"
+if cd "$ANNIE_PROJECT_DIR" && DATABASE_URL="$RELI_DB_URL" node scripts/export-to-sqlite.mjs "$RELI_OUT" 2>&1; then
+    SIZE=$(du -h "$RELI_OUT" | cut -f1)
+    THINGS=$(sqlite3 "$RELI_OUT" "SELECT count(*) FROM things" 2>/dev/null || echo "?")
+    log "Reli backed up: $RELI_OUT ($SIZE, $THINGS things)"
+else
+    log "ERROR: Reli Supabase export failed"
+fi
+
+# --- FilmDuel (Supabase PostgreSQL → pg_dump) ---
+FILMDUEL_BACKUP_DIR="$BACKUP_ROOT/filmduel"
+mkdir -p "$FILMDUEL_BACKUP_DIR"
+
+FILMDUEL_OUT="$FILMDUEL_BACKUP_DIR/filmduel-${TIMESTAMP}.sql.gz"
+if pg_dump "$FILMDUEL_DB_URL" --no-owner --no-acl 2>&1 | gzip > "$FILMDUEL_OUT"; then
+    SIZE=$(du -h "$FILMDUEL_OUT" | cut -f1)
+    USERS=$(psql "$FILMDUEL_DB_URL" -t -c "SELECT count(*) FROM users" 2>/dev/null | tr -d ' ' || echo "?")
+    log "FilmDuel backed up: $FILMDUEL_OUT ($SIZE, $USERS users)"
+    if [ "$USERS" = "0" ]; then
+        log "WARNING: FilmDuel backup has 0 users — possible data loss!"
+    fi
+else
+    log "ERROR: FilmDuel pg_dump failed"
+fi
+
+# --- Rotate old backups ---
+find "$ANNIE_BACKUP_DIR" -name "*.db" -mtime +$KEEP_DAYS -delete 2>/dev/null && \
+    log "Rotated Annie backups older than ${KEEP_DAYS} days" || true
+find "$RELI_BACKUP_DIR" -name "*.db" -mtime +$KEEP_DAYS -delete 2>/dev/null && \
+    log "Rotated Reli backups older than ${KEEP_DAYS} days" || true
+find "$FILMDUEL_BACKUP_DIR" -name "*.sql.gz" -mtime +$KEEP_DAYS -delete 2>/dev/null && \
+    log "Rotated FilmDuel backups older than ${KEEP_DAYS} days" || true
+
+# --- Google Drive sync (if rclone configured) ---
+if command -v rclone &>/dev/null && rclone listremotes 2>/dev/null | grep -q "^gdrive:"; then
+    rclone copy "$ANNIE_BACKUP_DIR" "$RCLONE_REMOTE/annie" --max-age 2d -q
+    rclone copy "$RELI_BACKUP_DIR" "$RCLONE_REMOTE/reli" --max-age 2d -q
+    rclone copy "$FILMDUEL_BACKUP_DIR" "$RCLONE_REMOTE/filmduel" --max-age 2d -q
+    log "Synced to Google Drive ($RCLONE_REMOTE)"
+else
+    log "SKIP: rclone/gdrive not configured, local backup only"
+fi
+
+log "Backup complete"

--- a/ops/cron/crontab
+++ b/ops/cron/crontab
@@ -1,0 +1,12 @@
+# Archon pipeline crontab. Install with: crontab ops/cron/crontab
+# Paths below assume this repo is checked out at /mnt/ext-fast/interstellarai.net.
+# Secrets loaded from ~/.config/archon-cron/secrets.env (not in this repo).
+
+*/15 * * * * /mnt/ext-fast/interstellarai.net/ops/cron/issue-pickup-cron.sh >> /tmp/issue-pickup.log 2>&1
+*/15 * * * * /mnt/ext-fast/archon/scripts/pr-maintenance-cron.sh >> /tmp/pr-maintenance.log 2>&1
+17 */3 * * * /mnt/ext-fast/interstellarai.net/ops/cron/backup-dbs.sh >> /tmp/db-backup.log 2>&1
+*/30 * * * * /mnt/ext-fast/interstellarai.net/ops/cron/pipeline-health-cron.sh >> /tmp/pipeline-health.log 2>&1
+0 8 * * * /mnt/ext-fast/interstellarai.net/ops/cron/daily-release-cron.sh >> /tmp/daily-release.log 2>&1
+*/5 * * * * /mnt/ext-fast/interstellarai.net/ops/cron/auto-apk-sync.sh >> /tmp/apk-sync.log 2>&1
+7 * * * * /usr/sbin/logrotate --state /home/asiri/.logrotate.state /home/asiri/.config/logrotate/archon-pipeline.conf >/dev/null 2>&1
+*/5 * * * * /mnt/ext-fast/interstellarai.net/ops/cron/pr-review-cron.sh >> /tmp/pr-review.log 2>&1

--- a/ops/cron/daily-release-cron.sh
+++ b/ops/cron/daily-release-cron.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# daily-release-cron.sh — run daily at 08:00 from cron.
+# For each project, if origin/main has new commits since the last
+# release-* tag, create a date tag `release-YYYY-MM-DD` and a GitHub
+# release with auto-generated notes.
+#
+# Crontab:
+#   0 8 * * * <repo>/ops/cron/daily-release-cron.sh >> /tmp/daily-release.log 2>&1
+
+set -uo pipefail
+
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+PROJECTS=(reli word-coach-annie filmduel cosmic-match un-reminder interstellarai.net)
+BASE_DIR="/mnt/ext-fast"
+OWNER="alexsiri7"
+LOG_PREFIX="[daily-release]"
+TODAY="$(date +%Y-%m-%d)"
+
+log() { echo "$(date -Is) $LOG_PREFIX $*"; }
+
+# Ask Gemini to write a 2-3 sentence human-readable highlight summary from
+# the auto-generated release body. Run from /tmp so per-project gemini MCP
+# configs don't break. Strip known noise prefix. Empty output on failure
+# (caller falls back to the plain auto-generated notes).
+summarize_release() {
+  local project="$1"
+  local body="$2"
+
+  # Condense the auto-generated body to just "- PR title" lines. Drops author
+  # suffixes, URLs, the contributors section, and the changelog footer — gemini
+  # only needs titles to summarize, and large bodies (30KB+) make it crawl or
+  # hang despite the timeout.
+  local titles
+  titles=$(echo "$body" | awk '
+    /^## New Contributors/ { skip=1 }
+    /^## What.?s Changed/ { section=1; next }
+    skip { next }
+    section && /^\* / {
+      sub(/^\* /, "")
+      sub(/ by @[^ ]+ in https.*$/, "")
+      print "- " $0
+    }')
+
+  [ -z "$titles" ] && return 1
+
+  # Cap at 80 most recent titles — huge first-time releases (200+ PRs) make
+  # gemini crawl, and a good summary doesn't need every entry. Daily releases
+  # going forward will be well under this.
+  titles=$(echo "$titles" | tail -n 80)
+
+  local prompt="Write 2-3 sentences of release-notes highlights for the project '${project}' based on this list of merged PR titles. Plain prose. No markdown headers, no preamble, no 'this release' filler.
+
+${titles}"
+
+  # -k 10: if gemini doesn't exit within 10s of the 120s SIGTERM, send SIGKILL.
+  # Plain `timeout 120 gemini ...` can leave gemini running because it catches
+  # SIGTERM and doesn't propagate to its node children.
+  local out
+  out=$(cd /tmp && timeout -k 10 120 gemini -p "$prompt" 2>/dev/null) || return 1
+  out="${out#MCP issues detected. Run /mcp list for status.}"
+  out=$(echo "$out" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  [ -z "$out" ] && return 1
+  printf '%s' "$out"
+}
+
+release_one() {
+  local project="$1"
+  local repo_dir="$BASE_DIR/$project"
+  local tag="release-$TODAY"
+
+  if [ ! -d "$repo_dir/.git" ]; then
+    log "$project: no repo at $repo_dir, skipping"
+    return
+  fi
+
+  cd "$repo_dir" || return
+
+  if ! git fetch --tags --quiet origin main 2>/dev/null; then
+    log "$project: git fetch failed, skipping"
+    return
+  fi
+
+  local head_sha
+  head_sha=$(git rev-parse origin/main 2>/dev/null) || {
+    log "$project: cannot resolve origin/main, skipping"
+    return
+  }
+
+  # Idempotent: if today's tag already exists on the remote, skip.
+  if git ls-remote --tags origin "refs/tags/$tag" 2>/dev/null | grep -q "$tag"; then
+    log "$project: tag $tag already exists, skipping"
+    return
+  fi
+
+  # Find previous release-* tag, if any.
+  local prev_tag
+  prev_tag=$(git tag -l 'release-*' --sort=-creatordate | head -n1)
+
+  local commit_count
+  if [ -n "$prev_tag" ]; then
+    commit_count=$(git rev-list --count "$prev_tag..$head_sha" 2>/dev/null || echo 0)
+  else
+    commit_count=$(git rev-list --count "$head_sha" 2>/dev/null || echo 0)
+  fi
+
+  if [ "$commit_count" -eq 0 ]; then
+    log "$project: no new commits since ${prev_tag:-repo start}, skipping"
+    return
+  fi
+
+  log "$project: releasing $tag ($commit_count commits since ${prev_tag:-repo start})"
+
+  if ! gh release create "$tag" \
+        --repo "$OWNER/$project" \
+        --target "$head_sha" \
+        --title "$tag" \
+        --generate-notes 2>&1 | sed "s/^/    /"; then
+    log "$project: gh release create failed"
+    return
+  fi
+
+  log "$project: released $tag — generating summary"
+
+  local body summary new_body
+  body=$(gh release view "$tag" --repo "$OWNER/$project" --json body --jq '.body' 2>/dev/null) || body=""
+  if [ -n "$body" ] && summary=$(summarize_release "$project" "$body"); then
+    new_body="## Highlights
+
+$summary
+
+---
+
+$body"
+    if gh release edit "$tag" --repo "$OWNER/$project" --notes "$new_body" >/dev/null 2>&1; then
+      log "$project: summary attached to $tag"
+    else
+      log "$project: summary generated but gh release edit failed"
+    fi
+  else
+    log "$project: summary unavailable — keeping plain auto-generated notes"
+  fi
+}
+
+for PROJECT in "${PROJECTS[@]}"; do
+  release_one "$PROJECT"
+done
+
+log "Done"

--- a/ops/cron/fetch-apks.sh
+++ b/ops/cron/fetch-apks.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# fetch-apks.sh — download the latest signed APKs from GitHub Actions for
+# our Android apps. Writes to ~/apks/<project>-<sha>.apk and symlinks
+# ~/apks/<project>-latest.apk to the most recent one.
+#
+# Usage:
+#   fetch-apks.sh                         # fetch all supported repos
+#   fetch-apks.sh un-reminder             # just this one
+#   fetch-apks.sh un-reminder cosmic-match
+
+set -uo pipefail
+
+OWNER="alexsiri7"
+APK_DIR="$HOME/apks"
+mkdir -p "$APK_DIR"
+
+# repo:workflow:artifact-name
+REPOS=(
+  "un-reminder:Release:app-release-"       # artifact name starts with this
+  "cosmic-match:CI:release-apk"
+)
+
+if [ $# -gt 0 ]; then
+  WANT=("$@")
+else
+  WANT=()
+  for entry in "${REPOS[@]}"; do WANT+=("${entry%%:*}"); done
+fi
+
+fetch_one() {
+  local project="$1" workflow="$2" artifact_pattern="$3"
+  local repo="$OWNER/$project"
+
+  echo ">>> $project ($repo)"
+
+  # Latest successful run on main for this workflow.
+  local run_info
+  run_info=$(gh run list --repo "$repo" --workflow "$workflow" \
+    --branch main --status success --limit 1 \
+    --json databaseId,headSha,createdAt 2>/dev/null)
+  local run_id sha created
+  run_id=$(echo "$run_info" | jq -r '.[0].databaseId // empty')
+  sha=$(echo "$run_info"    | jq -r '.[0].headSha // empty' | cut -c1-7)
+  created=$(echo "$run_info"| jq -r '.[0].createdAt // empty')
+
+  if [ -z "$run_id" ]; then
+    echo "  no successful $workflow run on main — skipping"
+    return 1
+  fi
+  echo "  run $run_id, sha $sha, $created"
+
+  # Find an artifact whose name matches our pattern and is not a CI throwaway.
+  local artifacts artifact_name
+  artifacts=$(gh api "repos/$repo/actions/runs/$run_id/artifacts" \
+    --jq '.artifacts[] | select(.expired == false) | .name' 2>/dev/null)
+  artifact_name=$(echo "$artifacts" | grep -E "^${artifact_pattern}" | grep -v "ci-throwaway" | head -n1)
+
+  if [ -z "$artifact_name" ]; then
+    echo "  no matching signed-APK artifact in run $run_id"
+    echo "  available: $(echo "$artifacts" | tr '\n' ' ')"
+    return 1
+  fi
+  echo "  artifact: $artifact_name"
+
+  # Download to a temp dir, then move the .apk out.
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmpdir'" RETURN
+
+  if ! gh run download "$run_id" --repo "$repo" --name "$artifact_name" --dir "$tmpdir" >/dev/null 2>&1; then
+    echo "  gh run download failed"
+    return 1
+  fi
+
+  local src_apk
+  src_apk=$(find "$tmpdir" -name '*.apk' -print -quit)
+  if [ -z "$src_apk" ]; then
+    echo "  artifact contained no .apk file"
+    return 1
+  fi
+
+  local dst="$APK_DIR/${project}-${sha}.apk"
+  mv -f "$src_apk" "$dst"
+  ln -sf "$(basename "$dst")" "$APK_DIR/${project}-latest.apk"
+  echo "  saved → $dst"
+  echo "  symlink → $APK_DIR/${project}-latest.apk"
+}
+
+failed=0
+for project in "${WANT[@]}"; do
+  match=""
+  for entry in "${REPOS[@]}"; do
+    if [ "${entry%%:*}" = "$project" ]; then match="$entry"; break; fi
+  done
+  if [ -z "$match" ]; then
+    echo ">>> $project: not a known Android repo, skipping"
+    continue
+  fi
+  # shellcheck disable=SC2162
+  IFS=':' read name workflow artifact <<<"$match"
+  fetch_one "$name" "$workflow" "$artifact" || failed=$((failed + 1))
+done
+
+echo
+if [ "$failed" -eq 0 ]; then
+  echo "All fetched. APKs in $APK_DIR:"
+else
+  echo "$failed project(s) had problems. APKs in $APK_DIR:"
+fi
+ls -la "$APK_DIR"/*-latest.apk 2>/dev/null || true

--- a/ops/cron/generate-android-keystore.sh
+++ b/ops/cron/generate-android-keystore.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# generate-android-keystore.sh — generate an Android release keystore and
+# upload it + its passwords as GitHub Actions secrets on the given repo.
+#
+# IMPORTANT: the keystore you create here is forever. Any future version of
+# the app that installs over an existing one MUST be signed with this same
+# keystore. Losing it means you can never update installed copies.
+#
+# Usage:
+#   generate-android-keystore.sh <github-repo>
+#
+# Example:
+#   generate-android-keystore.sh alexsiri7/cosmic-match
+#
+# Secret names written (matches cosmic-match/ci.yml expectations):
+#   KEYSTORE_BASE64           — base64 of the .jks file
+#   KEYSTORE_STORE_PASSWORD   — store password
+#   KEYSTORE_KEY_PASSWORD     — key password
+#   KEYSTORE_KEY_ALIAS        — key alias
+#
+# Outputs written locally (chmod 600):
+#   ~/keystores/<project>-release.jks
+#   ~/keystores/<project>-release.creds.txt  (passwords, alias, SHA256 fingerprint)
+
+set -euo pipefail
+
+REPO="${1:-}"
+if [ -z "$REPO" ] || [[ "$REPO" != */* ]]; then
+  echo "Usage: $(basename "$0") <owner/repo>" >&2
+  echo "  e.g. $(basename "$0") alexsiri7/cosmic-match" >&2
+  exit 2
+fi
+
+PROJECT="${REPO##*/}"
+KEYSTORE_DIR="$HOME/keystores"
+KEYSTORE_PATH="$KEYSTORE_DIR/${PROJECT}-release.jks"
+CREDS_PATH="$KEYSTORE_DIR/${PROJECT}-release.creds.txt"
+ALIAS="$PROJECT"
+VALIDITY_DAYS=10000  # ~27 years; Play Store requires ≥25
+
+for cmd in keytool gh openssl base64; do
+  command -v "$cmd" >/dev/null || { echo "missing: $cmd" >&2; exit 1; }
+done
+
+gh auth status >/dev/null 2>&1 || { echo "gh not authenticated" >&2; exit 1; }
+gh repo view "$REPO" >/dev/null 2>&1 || { echo "cannot access $REPO via gh" >&2; exit 1; }
+
+if [ -e "$KEYSTORE_PATH" ]; then
+  echo "Refusing to overwrite existing keystore: $KEYSTORE_PATH" >&2
+  echo "If you really want to rotate the key, move it aside first." >&2
+  exit 1
+fi
+
+echo ">>> This will generate a new release keystore for $REPO"
+echo "    Keystore path : $KEYSTORE_PATH"
+echo "    Alias         : $ALIAS"
+echo "    Validity      : $VALIDITY_DAYS days"
+echo
+echo "    The generated keystore becomes the single source of app identity."
+echo "    Lose it = can never update installed apps."
+read -r -p "Proceed? [y/N] " reply
+case "$reply" in [yY]|[yY][eE][sS]) ;; *) echo "aborted"; exit 1;; esac
+
+mkdir -p "$KEYSTORE_DIR"
+chmod 700 "$KEYSTORE_DIR"
+
+STORE_PASSWORD=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)
+# PKCS12 keystores ignore a separate -keypass; the key password is silently
+# forced equal to the store password. Use the same value for both so secrets
+# agree with reality.
+KEY_PASSWORD="$STORE_PASSWORD"
+
+echo ">>> Generating keystore…"
+keytool -genkeypair \
+  -keystore "$KEYSTORE_PATH" \
+  -storetype PKCS12 \
+  -alias "$ALIAS" \
+  -keyalg RSA -keysize 2048 \
+  -validity "$VALIDITY_DAYS" \
+  -storepass "$STORE_PASSWORD" -keypass "$KEY_PASSWORD" \
+  -dname "CN=$PROJECT, O=alexsiri7, L=Unknown, S=Unknown, C=US" \
+  >/dev/null 2>&1
+
+chmod 600 "$KEYSTORE_PATH"
+
+FINGERPRINT=$(keytool -list -v -keystore "$KEYSTORE_PATH" -storepass "$STORE_PASSWORD" -alias "$ALIAS" 2>/dev/null | awk '/SHA256:/ {print $2; exit}')
+
+cat > "$CREDS_PATH" <<EOF
+# Android release keystore credentials — KEEP SECRET
+# Generated: $(date -Is)
+# Repo: $REPO
+
+KEYSTORE_PATH=$KEYSTORE_PATH
+KEYSTORE_STORE_PASSWORD=$STORE_PASSWORD
+KEYSTORE_KEY_PASSWORD=$KEY_PASSWORD
+KEYSTORE_KEY_ALIAS=$ALIAS
+SHA256_FINGERPRINT=$FINGERPRINT
+EOF
+chmod 600 "$CREDS_PATH"
+
+echo ">>> Uploading secrets to $REPO…"
+KEYSTORE_B64=$(base64 -w0 < "$KEYSTORE_PATH")
+printf '%s' "$KEYSTORE_B64"          | gh secret set KEYSTORE_BASE64         --repo "$REPO"
+printf '%s' "$STORE_PASSWORD"        | gh secret set KEYSTORE_STORE_PASSWORD --repo "$REPO"
+printf '%s' "$KEY_PASSWORD"          | gh secret set KEYSTORE_KEY_PASSWORD   --repo "$REPO"
+printf '%s' "$ALIAS"                 | gh secret set KEYSTORE_KEY_ALIAS      --repo "$REPO"
+unset KEYSTORE_B64
+
+cat <<EOF
+
+>>> Done.
+
+Keystore : $KEYSTORE_PATH
+Creds    : $CREDS_PATH
+SHA256   : $FINGERPRINT
+
+Secrets uploaded to $REPO:
+  KEYSTORE_BASE64
+  KEYSTORE_STORE_PASSWORD
+  KEYSTORE_KEY_PASSWORD
+  KEYSTORE_KEY_ALIAS
+
+Back up both files above. If you ever lose them you cannot update users'
+installed apps — a new keystore forces uninstall+reinstall.
+EOF

--- a/ops/cron/install-apks.sh
+++ b/ops/cron/install-apks.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# install-apks.sh — install fetched APKs to a connected Android phone via adb.
+#
+# Usage:
+#   install-apks.sh                     # install all *-latest.apk in ~/apks
+#   install-apks.sh un-reminder         # just this one
+#   install-apks.sh /path/to/file.apk   # install a specific file
+
+set -uo pipefail
+
+APK_DIR="$HOME/apks"
+
+if ! command -v adb >/dev/null; then
+  echo "adb not installed. On Debian/Ubuntu: sudo apt install android-tools-adb" >&2
+  exit 1
+fi
+
+# Enumerate connected devices (skip 'unauthorized' and 'offline').
+mapfile -t DEVICES < <(adb devices | awk 'NR>1 && $2=="device" {print $1}')
+
+if [ "${#DEVICES[@]}" -eq 0 ]; then
+  echo "No authorized Android device connected." >&2
+  echo "Checklist:" >&2
+  echo "  1. Plug the phone in via USB." >&2
+  echo "  2. Enable Developer options → USB debugging on the phone." >&2
+  echo "  3. Accept the RSA fingerprint prompt on the phone when adb attaches." >&2
+  echo "  4. Confirm with: adb devices" >&2
+  exit 1
+fi
+
+echo "Connected device(s): ${DEVICES[*]}"
+
+TARGETS=()
+if [ $# -eq 0 ]; then
+  # Install all -latest.apk files
+  shopt -s nullglob
+  for f in "$APK_DIR"/*-latest.apk; do TARGETS+=("$f"); done
+  shopt -u nullglob
+else
+  for arg in "$@"; do
+    if [ -f "$arg" ]; then
+      TARGETS+=("$arg")
+    elif [ -f "$APK_DIR/${arg}-latest.apk" ]; then
+      TARGETS+=("$APK_DIR/${arg}-latest.apk")
+    else
+      echo "Not found: $arg (neither a path nor a project name in $APK_DIR)" >&2
+      exit 1
+    fi
+  done
+fi
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+  echo "No APKs to install. Run fetch-apks.sh first." >&2
+  exit 1
+fi
+
+FAILED=0
+for apk in "${TARGETS[@]}"; do
+  # Resolve symlinks for display clarity.
+  real=$(readlink -f "$apk" 2>/dev/null || echo "$apk")
+  echo
+  echo ">>> Installing $(basename "$apk") ($(basename "$real"))"
+  for dev in "${DEVICES[@]}"; do
+    echo "    → device $dev"
+    # -r: reinstall keeping data. -d: allow version downgrade.
+    if ! adb -s "$dev" install -r -d "$apk"; then
+      echo "    install failed on $dev (signature mismatch? uninstall first with: adb -s $dev uninstall <package>)" >&2
+      FAILED=$((FAILED + 1))
+    fi
+  done
+done
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+  echo "All installed."
+else
+  echo "$FAILED install(s) failed."
+  exit 1
+fi

--- a/ops/cron/issue-pickup-cron.sh
+++ b/ops/cron/issue-pickup-cron.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# issue-pickup-cron.sh — run every 15 minutes from cron.
+# Autonomous pipeline: auto-labels new issues, then picks up one per repo
+# per tick and fires archon-fix-github-issue on the oldest queued one.
+#
+# Crontab:
+#   */15 * * * * <repo>/ops/cron/issue-pickup-cron.sh >> /tmp/issue-pickup.log 2>&1
+
+set -uo pipefail
+
+# Cron has a minimal PATH; prepend where archon / gh / bun live.
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/archon-projects.sh
+source "$SCRIPT_DIR/lib/archon-projects.sh"
+load_archon_projects DEFAULT_PROJECTS
+
+# Age (seconds) after which an issue labeled archon:in-progress with no
+# corresponding live archon process and no open PR is considered stuck and
+# re-queued. Archon workflows usually finish in under an hour; 2h gives
+# plenty of margin for slow CI and rate-limit backoff.
+STUCK_AGE_SECONDS=7200
+BASE_DIR="/mnt/ext-fast"
+LOG_PREFIX="[issue-pickup]"
+
+# Labels that make an issue a candidate for autonomous processing.
+INGEST_LABELS=("enhancement" "bug")
+
+# Labels archon already manages — presence of any of these means "don't re-queue".
+ARCHON_LABELS=("archon:queued" "archon:in-progress" "archon:done" "archon:failed" "archon:skipped")
+
+PROJECTS=("${DEFAULT_PROJECTS[@]}")
+[ $# -gt 0 ] && PROJECTS=("$@")
+
+log() { echo "$(date -Is) $LOG_PREFIX $*"; }
+
+# Per-tick, per-project summary state. Reset at the start of each project
+# iteration, populated by the three phases, emitted after pick_and_fire.
+SUMMARY_IN_PROGRESS=0
+SUMMARY_STALE=0
+SUMMARY_QUEUED=0
+SUMMARY_ACTION="none"
+SUMMARY_NOTE=""
+
+ensure_labels() {
+  local repo="$1"
+  for label in archon:queued archon:in-progress archon:done archon:failed archon:skipped; do
+    gh label create "$label" --repo "alexsiri7/$repo" \
+      --color "c2e0c6" --description "Archon pipeline state" 2>/dev/null || true
+  done
+}
+
+has_archon_label() {
+  local labels="$1"
+  for al in "${ARCHON_LABELS[@]}"; do
+    echo "$labels" | grep -q "\"$al\"" && return 0
+  done
+  return 1
+}
+
+# --- Phase 0: un-stick stale archon:in-progress issues ---
+# If an issue has been archon:in-progress for a long time and there's no
+# running archon process for it and no open PR that references it, treat it
+# as stuck (e.g. previous run died from rate-limit or crash) and re-queue.
+# Uses the timeline API to find when the in-progress label was last added.
+unstick_stale() {
+  local project="$1"
+  local repo_dir="$BASE_DIR/$project"
+  local issues
+  issues=$(gh issue list --repo "alexsiri7/$project" --state open \
+    --label "archon:in-progress" --limit 50 --json number 2>/dev/null || echo "[]")
+
+  local nums
+  nums=$(echo "$issues" | jq -r '.[].number' 2>/dev/null)
+  SUMMARY_IN_PROGRESS=$(echo "$issues" | jq 'length' 2>/dev/null || echo 0)
+  [ -z "$nums" ] && return
+
+  local now_sec; now_sec=$(date +%s)
+
+  local num
+  for num in $nums; do
+    # Skip if a live archon process is working on this issue's repo and
+    # references this issue number. Best-effort — we match on the archon
+    # command line which includes the issue number in "fix #N".
+    # Anchor project match to $repo_dir so e.g. `reli` does not substring-match
+    # a worktree path containing `reliability`.
+    if pgrep -fa "archon workflow run archon-fix-github-issue.*#$num\\b" >/dev/null 2>&1 \
+        && pgrep -fa "archon workflow run archon-fix-github-issue" | grep -qE "(^|[[:space:]=/])$project([[:space:]/]|\$)"; then
+      continue
+    fi
+
+    # Skip if any open PR body/title references this issue (GH auto-links
+    # "Fixes #N" / "Closes #N", and archon's PRs include "Closes #N").
+    local linked_prs
+    linked_prs=$(gh pr list --repo "alexsiri7/$project" --state open --search "#$num in:body,title" --json number --jq 'length' 2>/dev/null || echo 0)
+    if [ "${linked_prs:-0}" -gt 0 ]; then
+      continue
+    fi
+
+    # Find when archon:in-progress was last added via timeline events.
+    local labeled_at
+    labeled_at=$(gh api "repos/alexsiri7/$project/issues/$num/timeline" \
+      --jq '[.[] | select(.event=="labeled" and .label.name=="archon:in-progress") | .created_at] | last' 2>/dev/null || echo "")
+    [ -z "$labeled_at" ] || [ "$labeled_at" = "null" ] && continue
+
+    local labeled_sec; labeled_sec=$(date -d "$labeled_at" +%s 2>/dev/null || echo 0)
+    local age=$((now_sec - labeled_sec))
+    if [ "$age" -lt "$STUCK_AGE_SECONDS" ]; then
+      continue
+    fi
+
+    log "$project: #$num is stuck (in-progress for ${age}s, no process, no PR) — re-queuing"
+    gh issue edit "$num" --repo "alexsiri7/$project" \
+      --remove-label "archon:in-progress" --add-label "archon:queued" 2>/dev/null || {
+        log "$project: #$num — could not swap labels"
+        continue
+      }
+    SUMMARY_STALE=$((SUMMARY_STALE + 1))
+    gh issue comment "$num" --repo "alexsiri7/$project" \
+      --body "archon was labeled in-progress ${age}s ago but no live run and no linked PR were found. Re-queued for another attempt." 2>/dev/null || true
+  done
+}
+
+# --- Phase 1: auto-queue discovered issues ---
+# Find issues labeled with any INGEST_LABEL that have NO archon:* label yet,
+# add archon:queued to them. Only for issues older than 5 minutes to let
+# humans explicitly skip via archon:skipped if they want to.
+auto_queue() {
+  local project="$1"
+  local issues
+  issues=$(gh issue list --repo "alexsiri7/$project" --state open --limit 100 \
+    --json number,labels,createdAt 2>/dev/null || echo "[]")
+
+  local now_sec; now_sec=$(date +%s)
+  echo "$issues" | jq -c '.[]' 2>/dev/null | while read -r row; do
+    local num created has_ingest
+    num=$(echo "$row" | jq -r '.number')
+    created=$(echo "$row" | jq -r '.createdAt')
+    local labels_json
+    labels_json=$(echo "$row" | jq -c '[.labels[].name]')
+
+    if has_archon_label "$labels_json"; then
+      continue
+    fi
+
+    # Must have at least one ingest label
+    has_ingest=0
+    for il in "${INGEST_LABELS[@]}"; do
+      echo "$labels_json" | grep -q "\"$il\"" && has_ingest=1 && break
+    done
+    [ "$has_ingest" = "1" ] || continue
+
+    # Age check: must be > 5 min old
+    local created_sec; created_sec=$(date -d "$created" +%s 2>/dev/null || echo 0)
+    local age=$((now_sec - created_sec))
+    [ "$age" -lt 300 ] && continue
+
+    log "$project: auto-queuing #$num (age ${age}s)"
+    gh issue edit "$num" --repo "alexsiri7/$project" --add-label "archon:queued" 2>/dev/null || \
+      log "$project: #$num — could not add archon:queued label"
+  done
+}
+
+# --- Phase 2: pick up oldest queued issue per repo and fire archon ---
+pick_and_fire() {
+  local project="$1"
+  local repo_dir="$BASE_DIR/$project"
+
+  # Fetch queued list once, reuse for count + pick. Oldest-first is gh's default.
+  local queued_json
+  queued_json=$(gh issue list --repo "alexsiri7/$project" --state open \
+    --label "archon:queued" --limit 50 --json number 2>/dev/null || echo "[]")
+  SUMMARY_QUEUED=$(echo "$queued_json" | jq 'length' 2>/dev/null || echo 0)
+
+  if [ ! -d "$repo_dir/.git" ]; then
+    log "$project: no repo at $repo_dir, skipping"
+    SUMMARY_ACTION="skip"
+    SUMMARY_NOTE="repo missing"
+    return
+  fi
+
+  # Don't stack — if an archon run is already in flight for this repo, skip.
+  # Capture the issue number from the cmdline ("fix #N") for the summary note.
+  local running_for
+  running_for=$(pgrep -fa "archon workflow run archon-fix-github-issue.*--cwd.*$repo_dir" 2>/dev/null \
+    | grep -oE 'fix #[0-9]+' | head -1 | tr -d '#')
+  if [ -n "$running_for" ]; then
+    log "$project: archon already running, skipping"
+    SUMMARY_ACTION="skip-running"
+    SUMMARY_NOTE="archon already running for #$running_for"
+    return
+  fi
+  # Fallback detector: look for runs started via direct cd (no --cwd).
+  # Anchor project match so e.g. `reli` does not false-positive on
+  # `reliability` or another slug containing the substring.
+  running_for=$(pgrep -fa "archon workflow run archon-fix-github-issue" 2>/dev/null \
+    | grep -E "(^|[[:space:]=/])$project([[:space:]/]|\$)" | grep -oE 'fix #[0-9]+' | head -1 | tr -d '#')
+  if [ -n "$running_for" ]; then
+    log "$project: archon already running (cwd match), skipping"
+    SUMMARY_ACTION="skip-running"
+    SUMMARY_NOTE="archon already running for #$running_for"
+    return
+  fi
+
+  local issue
+  issue=$(echo "$queued_json" | jq -r '.[0].number // empty' 2>/dev/null || echo "")
+
+  if [ -z "$issue" ]; then
+    return  # nothing queued; SUMMARY_ACTION stays "none"
+  fi
+
+  log "$project: picking up issue #$issue"
+  gh issue edit "$issue" --repo "alexsiri7/$project" \
+    --remove-label "archon:queued" --add-label "archon:in-progress" 2>/dev/null || true
+  SUMMARY_ACTION="pickup #$issue"
+
+  cd "$repo_dir"
+  mkdir -p .archon-logs
+  local logf=".archon-logs/cron-issue-$issue-$(date +%Y%m%d-%H%M%S).log"
+  CLAUDECODE=0 nohup archon workflow run archon-fix-github-issue "fix #$issue" \
+    >"$logf" 2>&1 &
+  disown
+  log "$project: archon launched for #$issue (pid=$!, log=$logf)"
+}
+
+for PROJECT in "${PROJECTS[@]}"; do
+  SUMMARY_IN_PROGRESS=0
+  SUMMARY_STALE=0
+  SUMMARY_QUEUED=0
+  SUMMARY_ACTION="none"
+  SUMMARY_NOTE=""
+
+  ensure_labels "$PROJECT"
+  unstick_stale "$PROJECT"
+  auto_queue "$PROJECT"
+  pick_and_fire "$PROJECT"
+
+  summary="$PROJECT: queued=$SUMMARY_QUEUED in-progress=$SUMMARY_IN_PROGRESS stale=$SUMMARY_STALE action=$SUMMARY_ACTION"
+  [ -n "$SUMMARY_NOTE" ] && summary="$summary ($SUMMARY_NOTE)"
+  log "$summary"
+done
+
+log "Done"

--- a/ops/cron/lib/archon-projects.sh
+++ b/ops/cron/lib/archon-projects.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Shared loader for the archon-managed project list.
+# Usage:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/archon-projects.sh"
+#   load_archon_projects MY_ARRAY
+# Reads from $ARCHON_PROJECTS_FILE (default: archon-projects.txt sibling of the
+# lib/ directory), one project per line. Lines may contain trailing `#`
+# comments; blank lines and comment-only lines are ignored. Duplicates deduped.
+# On missing or empty file, logs to stderr and exits 1.
+
+# Populates the named array arg with the deduped project list.
+# Usage: load_archon_projects PROJECTS
+load_archon_projects() {
+    local _out_name="$1"
+    local _lib_dir
+    _lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local _file="${ARCHON_PROJECTS_FILE:-$_lib_dir/../archon-projects.txt}"
+
+    if [ ! -f "$_file" ]; then
+        echo "archon-projects: file not found: $_file" >&2
+        exit 1
+    fi
+
+    local -a _tmp=()
+    local -A _seen=()
+    local _line
+    while IFS= read -r _line || [ -n "$_line" ]; do
+        # Strip comments (everything from first '#') and all whitespace
+        _line="${_line%%#*}"
+        _line="${_line//[[:space:]]/}"
+        [ -z "$_line" ] && continue
+        if [ -z "${_seen[$_line]:-}" ]; then
+            _seen[$_line]=1
+            _tmp+=("$_line")
+        fi
+    done < "$_file"
+
+    if [ "${#_tmp[@]}" -eq 0 ]; then
+        echo "archon-projects: no projects parsed from $_file (file empty or all comments)" >&2
+        exit 1
+    fi
+
+    # Assign to caller's array by name. Using eval for broad bash-4 compatibility
+    # (nameref requires bash 4.3+; most systems have it but eval is safer).
+    eval "$_out_name=(\"\${_tmp[@]}\")"
+}

--- a/ops/cron/pipeline-health-cron.sh
+++ b/ops/cron/pipeline-health-cron.sh
@@ -1,0 +1,443 @@
+#!/usr/bin/env bash
+# pipeline-health-cron.sh — runs every 30 minutes from cron.
+# Detects and responds to pipeline-bottleneck states:
+#   1. Main CI red → file issue tagged archon:in-progress + fire archon immediately (dedup by SHA)
+#   2. Prod deploy failed or lagging main HEAD → file issue + fire archon (dedup by SHA)
+#   3. Zombie archon DB runs (status=running, age >4h) → abandon
+#   4. Disk >85% on / or /mnt/ext-fast → ntfy
+#   5. No pipeline progress in last tick (no commits, no archon completions):
+#        - If token-limit markers in recent logs → wait, retry next tick
+#        - Else → fire archon-assist diagnostic (dedup: 2h cooldown)
+#
+# Crontab:
+#   */30 * * * * <repo>/ops/cron/pipeline-health-cron.sh >> /tmp/pipeline-health.log 2>&1
+
+set -uo pipefail
+
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/archon-projects.sh
+source "$SCRIPT_DIR/lib/archon-projects.sh"
+load_archon_projects REPOS
+BASE_DIR="/mnt/ext-fast"
+STATE_DIR="$HOME/.archon/pipeline-health-state"
+
+# NTFY_TOPIC loaded from secrets.env. Fail loud if unset.
+SECRETS_FILE="${ARCHON_CRON_SECRETS:-$HOME/.config/archon-cron/secrets.env}"
+# shellcheck source=/dev/null
+[ -r "$SECRETS_FILE" ] && . "$SECRETS_FILE"
+: "${NTFY_TOPIC:?NTFY_TOPIC not set — populate $SECRETS_FILE}"
+LOG_PREFIX="[pipeline-health]"
+
+mkdir -p "$STATE_DIR"
+
+log() { echo "$(date -Is) $LOG_PREFIX $*"; }
+
+notify() {
+  local title="$1" msg="$2" priority="${3:-default}" tags="${4:-robot}"
+  curl -s -o /dev/null \
+    -H "Title: $title" -H "Priority: $priority" -H "Tags: $tags" \
+    -d "$msg" "ntfy.sh/$NTFY_TOPIC" 2>/dev/null || true
+}
+
+# ----------------------------------------------------------------------------
+# Check 1: Main CI red — file issue + fire archon immediately, dedup by SHA.
+# ----------------------------------------------------------------------------
+check_main_ci() {
+  local project="$1"
+  local repo_dir="$BASE_DIR/$project"
+  [ -d "$repo_dir/.git" ] || return
+
+  local latest
+  latest=$(gh run list --repo "alexsiri7/$project" --branch main --limit 1 \
+    --json databaseId,conclusion,headSha --jq '.[0] // empty' 2>/dev/null || echo "")
+  [ -n "$latest" ] || return
+
+  local conclusion sha run_id
+  conclusion=$(echo "$latest" | jq -r '.conclusion // "pending"')
+  sha=$(echo "$latest" | jq -r '.headSha')
+  run_id=$(echo "$latest" | jq -r '.databaseId')
+
+  if [ "$conclusion" = "success" ]; then
+    # Green again — clear stale markers for this repo
+    find "$STATE_DIR" -maxdepth 1 -name "main-ci-fired-$project-*" -delete 2>/dev/null || true
+    return
+  fi
+  # Still running, cancelled, or pending — not actionable yet
+  [ "$conclusion" = "failure" ] || return
+
+  local marker="$STATE_DIR/main-ci-fired-$project-$sha"
+  if [ -f "$marker" ]; then
+    log "$project: main CI still red at $sha — archon already fired, skipping"
+    return
+  fi
+
+  # Also skip if a human (or earlier tick) already filed an open "Main CI" issue
+  # that is queued or in-progress. Avoids duplicating triage on SHA changes.
+  local existing
+  existing=$(gh issue list --repo "alexsiri7/$project" --state open \
+    --search "Main CI in:title" --json number,labels \
+    --jq '[.[] | select((.labels | map(.name)) as $l | ($l | index("archon:queued")) or ($l | index("archon:in-progress")))] | .[0].number // empty' \
+    2>/dev/null || echo "")
+  if [ -n "$existing" ]; then
+    log "$project: main CI red, but open CI issue #$existing already queued/in-progress — marker set, skipping"
+    touch "$marker"
+    return
+  fi
+
+  local failed_jobs
+  failed_jobs=$(gh run view "$run_id" --repo "alexsiri7/$project" --json jobs \
+    --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")' 2>/dev/null || echo "unknown")
+
+  log "$project: main CI red ($failed_jobs) at $sha — filing issue + firing archon"
+
+  local issue_body
+  issue_body=$(cat <<EOF
+## Main CI red
+
+**Repo**: alexsiri7/$project
+**SHA**: \`$sha\`
+**Run**: https://github.com/alexsiri7/$project/actions/runs/$run_id
+**Failed jobs**: $failed_jobs
+
+Auto-filed by \`pipeline-health-cron.sh\`. Main CI is a pipeline bottleneck, so archon has been fired immediately on this issue rather than queued. This issue is tagged \`archon:in-progress\` so the regular pickup cron will not double-fire.
+
+### Steps
+1. \`gh run view $run_id --repo alexsiri7/$project --log-failed\`
+2. Identify root cause (dep bump? toolchain? flaky test?)
+3. Fix on a branch, open PR, ensure CI goes green
+EOF
+)
+  local issue_url
+  issue_url=$(gh issue create --repo "alexsiri7/$project" \
+    --title "Main CI red: $failed_jobs" \
+    --label "bug,archon:in-progress" \
+    --body "$issue_body" 2>/dev/null | tail -1)
+
+  local issue_num
+  issue_num=$(echo "$issue_url" | grep -oE '[0-9]+$')
+  if [ -z "$issue_num" ]; then
+    log "$project: could not create issue — skipping archon fire (will retry next tick)"
+    return
+  fi
+
+  touch "$marker"
+
+  mkdir -p "$repo_dir/.archon-logs"
+  local logf="$repo_dir/.archon-logs/health-ci-fix-${sha:0:8}-$(date +%Y%m%d-%H%M%S).log"
+  (
+    cd "$repo_dir"
+    CLAUDECODE=0 nohup archon workflow run archon-fix-github-issue "fix #$issue_num" \
+      > "$logf" 2>&1 &
+    disown
+  )
+  log "$project: archon fired for issue #$issue_num (log $logf)"
+}
+
+# ----------------------------------------------------------------------------
+# Check 2: Prod deploy health — failed or lagging main HEAD.
+#   Signal sources (try in order, use whichever exists):
+#     (a) GH Actions workflow matching "Production" (Reli, WCA use "Staging → Production Pipeline")
+#     (b) GitHub deployments API, environment matches "production" (Railway native integration, FilmDuel)
+#   If deploy FAILED → file issue + fire archon (dedup by deploy SHA).
+#   If last successful deploy SHA != main HEAD AND main HEAD older than 15 min → file lag issue.
+#   Projects with no deploy signal are skipped silently.
+# ----------------------------------------------------------------------------
+check_prod_deploy() {
+  local project="$1"
+  local repo_dir="$BASE_DIR/$project"
+  [ -d "$repo_dir/.git" ] || return
+
+  local head_json head_sha head_ts
+  head_json=$(gh api "repos/alexsiri7/$project/commits/main" \
+    --jq '{sha: .sha, ts: .commit.committer.date}' 2>/dev/null || echo "")
+  [ -n "$head_json" ] || return
+  head_sha=$(echo "$head_json" | jq -r '.sha')
+  head_ts=$(echo "$head_json" | jq -r '.ts')
+
+  # --- Source (a): GH Actions deploy workflow ---
+  local deploy_sha="" deploy_ts="" deploy_state="" deploy_url=""
+  local wf_run
+  wf_run=$(gh run list --repo "alexsiri7/$project" --branch main --limit 10 \
+    --json name,headSha,updatedAt,conclusion,url \
+    --jq '[.[] | select(.name | test("Production"; "i"))] | .[0] // empty' \
+    2>/dev/null || echo "")
+  if [ -n "$wf_run" ]; then
+    deploy_sha=$(echo "$wf_run" | jq -r '.headSha')
+    deploy_ts=$(echo "$wf_run" | jq -r '.updatedAt')
+    deploy_state=$(echo "$wf_run" | jq -r '.conclusion // "pending"')
+    deploy_url=$(echo "$wf_run" | jq -r '.url')
+  fi
+
+  # --- Source (b): GitHub deployments API (Railway native) ---
+  if [ -z "$deploy_sha" ]; then
+    local dep
+    dep=$(gh api "repos/alexsiri7/$project/deployments?per_page=10" \
+      --jq '[.[] | select(.environment | test("production"; "i"))] | .[0] // empty' \
+      2>/dev/null || echo "")
+    if [ -n "$dep" ]; then
+      deploy_sha=$(echo "$dep" | jq -r '.sha')
+      deploy_ts=$(echo "$dep" | jq -r '.created_at')
+      local dep_id
+      dep_id=$(echo "$dep" | jq -r '.id')
+      deploy_state=$(gh api "repos/alexsiri7/$project/deployments/$dep_id/statuses?per_page=1" \
+        --jq '.[0].state // "pending"' 2>/dev/null || echo "pending")
+      deploy_url="https://github.com/alexsiri7/$project/deployments"
+    fi
+  fi
+
+  [ -n "$deploy_sha" ] || return  # No deploy signal — skip silently
+
+  # --- Case 1: deploy FAILED ---
+  if [ "$deploy_state" = "failure" ] || [ "$deploy_state" = "error" ]; then
+    local marker="$STATE_DIR/prod-deploy-failed-$project-${deploy_sha:0:12}"
+    if [ -f "$marker" ]; then
+      log "$project: prod deploy still failed at ${deploy_sha:0:10} — already filed, skipping"
+      return
+    fi
+
+    local existing
+    existing=$(gh issue list --repo "alexsiri7/$project" --state open \
+      --search "Prod deploy in:title" --json number,labels \
+      --jq '[.[] | select((.labels | map(.name)) as $l | ($l | index("archon:queued")) or ($l | index("archon:in-progress")))] | .[0].number // empty' \
+      2>/dev/null || echo "")
+    if [ -n "$existing" ]; then
+      log "$project: prod deploy failed, but open issue #$existing already queued — marker set, skipping"
+      touch "$marker"
+      return
+    fi
+
+    log "$project: prod deploy FAILED at ${deploy_sha:0:10} — filing issue + firing archon"
+
+    local body
+    body=$(cat <<EOF
+## Prod deploy failed
+
+**Repo**: alexsiri7/$project
+**SHA**: \`$deploy_sha\`
+**Deploy run/status**: $deploy_url
+**State**: $deploy_state
+**Deployed at**: $deploy_ts
+
+Auto-filed by \`pipeline-health-cron.sh\`. Prod deploy is a pipeline bottleneck — archon has been fired immediately. This issue is tagged \`archon:in-progress\` so the pickup cron will not double-fire.
+
+### Steps
+1. Inspect deploy logs at $deploy_url
+2. Identify root cause (Railway config? env var? build error? migration?)
+3. Fix on a branch, land, confirm next deploy goes green
+EOF
+)
+    local issue_url
+    issue_url=$(gh issue create --repo "alexsiri7/$project" \
+      --title "Prod deploy failed on main" \
+      --label "bug,archon:in-progress" \
+      --body "$body" 2>/dev/null | tail -1)
+    local issue_num
+    issue_num=$(echo "$issue_url" | grep -oE '[0-9]+$')
+    if [ -z "$issue_num" ]; then
+      log "$project: could not create prod-deploy issue — skipping archon fire"
+      return
+    fi
+
+    touch "$marker"
+    # No ntfy — archon has been fired and will auto-fix. If it can't,
+    # the issue stays open and pipeline-health re-tries on the next tick.
+
+    mkdir -p "$repo_dir/.archon-logs"
+    local logf="$repo_dir/.archon-logs/health-prod-deploy-${deploy_sha:0:8}-$(date +%Y%m%d-%H%M%S).log"
+    (
+      cd "$repo_dir"
+      CLAUDECODE=0 nohup archon workflow run archon-fix-github-issue "fix #$issue_num" \
+        > "$logf" 2>&1 &
+      disown
+    )
+    log "$project: archon fired for issue #$issue_num (log $logf)"
+    return
+  fi
+
+  # --- Case 2: deploy succeeded but lagging main HEAD ---
+  if [ "$deploy_state" = "success" ] && [ "$deploy_sha" != "$head_sha" ]; then
+    local head_epoch now_epoch
+    head_epoch=$(date -d "$head_ts" +%s 2>/dev/null || echo 0)
+    now_epoch=$(date +%s)
+    local age=$((now_epoch - head_epoch))
+    if [ "$age" -gt 900 ]; then
+      local marker="$STATE_DIR/prod-deploy-stale-$project-${head_sha:0:12}"
+      if [ -f "$marker" ]; then
+        log "$project: prod still lagging main ${head_sha:0:10} (age ${age}s) — already filed, skipping"
+        return
+      fi
+
+      log "$project: prod LAGGING — main=${head_sha:0:10} prod=${deploy_sha:0:10} (head age ${age}s)"
+
+      local body
+      body=$(cat <<EOF
+## Prod deploy lagging main
+
+**Repo**: alexsiri7/$project
+**main HEAD**: \`$head_sha\` (committed $head_ts, age ${age}s)
+**Latest prod deploy**: \`$deploy_sha\` at $deploy_ts
+**Deploy source**: $deploy_url
+
+Auto-filed by \`pipeline-health-cron.sh\`. main has been ahead of prod for >15 minutes, which suggests the deploy mechanism (Railway webhook, GH Actions workflow) did not fire or silently failed.
+
+### Steps
+1. Check $deploy_url — is there a run for $head_sha?
+2. If Railway-native: inspect Railway dashboard for the service, check webhook delivery
+3. If GH Actions: re-dispatch the deploy workflow on main
+EOF
+)
+      gh issue create --repo "alexsiri7/$project" \
+        --title "Prod deploy lagging main" \
+        --label "bug,archon:queued" \
+        --body "$body" >/dev/null 2>&1 || true
+
+      touch "$marker"
+      # No ntfy — archon will handle the issue automatically.
+      return
+    fi
+  fi
+
+  # Deploy up to date — clear stale markers
+  find "$STATE_DIR" -maxdepth 1 \( -name "prod-deploy-failed-$project-*" -o -name "prod-deploy-stale-$project-*" \) -delete 2>/dev/null || true
+}
+
+# ----------------------------------------------------------------------------
+# Check 3: Abandon archon DB runs marked "running" for >4h — likely orphaned.
+# ----------------------------------------------------------------------------
+reconcile_zombies() {
+  local status_out
+  status_out=$(cd "$BASE_DIR/archon" && \
+    CLAUDECODE=0 ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1 archon workflow status 2>/dev/null || true)
+  [ -n "$status_out" ] || return
+
+  echo "$status_out" | awk '
+    /^ *ID: / { id = $2 }
+    /^ *Age: / {
+      age_str = $2
+      age_hours = 0
+      if (age_str ~ /d$/) {
+        age_hours = 24
+      } else if (age_str ~ /h$/) {
+        n = age_str
+        gsub(/h$/, "", n)
+        age_hours = n + 0
+      }
+      if (age_hours >= 4) print id
+    }
+  ' | while read -r stale_id; do
+    [ -n "$stale_id" ] || continue
+    log "abandoning stale archon run $stale_id (age >=4h)"
+    (cd "$BASE_DIR/archon" && \
+      CLAUDECODE=0 ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1 \
+      archon workflow abandon "$stale_id" 2>&1 | tail -1)
+  done
+}
+
+# ----------------------------------------------------------------------------
+# Check 3: Disk warning — ntfy if / or /mnt/ext-fast above 85%.
+# ----------------------------------------------------------------------------
+check_disk() {
+  for mount in / /mnt/ext-fast; do
+    local used
+    used=$(df -P "$mount" 2>/dev/null | awk 'NR==2 { gsub("%",""); print $5 }')
+    [ -n "$used" ] || continue
+    if [ "$used" -ge 85 ]; then
+      log "disk $mount at ${used}% — ntfying"
+      notify "Disk warning: $mount ${used}%" \
+        "Pipeline will stall if this fills. Investigate and clean." \
+        high warning
+    fi
+  done
+}
+
+# ----------------------------------------------------------------------------
+# Check 4: Progress detection.
+#   Signal = commits to origin/main across repos + archon log completions since
+#   the last health tick. If zero: look for token-limit markers first (expected,
+#   transient). If none, fire archon-assist to diagnose (cooldown: 2h).
+# ----------------------------------------------------------------------------
+check_progress() {
+  local progress_marker="$STATE_DIR/last-progress-ts"
+  local now; now=$(date +%s)
+  local last_ts=0
+  [ -f "$progress_marker" ] && last_ts=$(cat "$progress_marker" 2>/dev/null || echo 0)
+  echo "$now" > "$progress_marker"
+
+  # First run after install — baseline only
+  [ "$last_ts" -eq 0 ] && { log "progress baseline set, skipping first check"; return; }
+
+  local since_iso
+  since_iso=$(date -u -d "@$last_ts" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")
+  [ -n "$since_iso" ] || return
+
+  local commits=0 completions=0
+  for project in "${REPOS[@]}"; do
+    local n
+    n=$(gh api "repos/alexsiri7/$project/commits?sha=main&since=$since_iso" \
+        --jq 'length' 2>/dev/null || echo 0)
+    commits=$((commits + n))
+
+    local logdir="$BASE_DIR/$project/.archon-logs"
+    [ -d "$logdir" ] || continue
+    local m
+    m=$(find "$logdir" -name "*.log" -newermt "@$last_ts" \
+          -exec grep -l 'dag_workflow_finished' {} \; 2>/dev/null | wc -l)
+    completions=$((completions + m))
+  done
+
+  log "progress: $commits commits on main, $completions archon completions since last tick"
+  [ $((commits + completions)) -gt 0 ] && return
+
+  # No progress — check for token-limit markers
+  local token_hint=0
+  for project in "${REPOS[@]}"; do
+    local logdir="$BASE_DIR/$project/.archon-logs"
+    [ -d "$logdir" ] || continue
+    if find "$logdir" -name "*.log" -newermt "@$last_ts" 2>/dev/null \
+         -exec grep -liE 'rate.?limit|rate_limit| 429 |http.?429|quota.?exceed|overloaded|usage.?limit|credit.?exhaust' {} \; \
+         2>/dev/null | head -1 | grep -q .; then
+      token_hint=1; break
+    fi
+  done
+
+  if [ "$token_hint" = "1" ]; then
+    log "no progress but token-limit markers found — likely quota, retrying next tick"
+    return
+  fi
+
+  # Cooldown: only fire diagnostic if we haven't in the last 2h
+  local stall_marker="$STATE_DIR/last-stall-diagnostic-ts"
+  local last_stall=0
+  [ -f "$stall_marker" ] && last_stall=$(cat "$stall_marker" 2>/dev/null || echo 0)
+  if [ $((now - last_stall)) -lt 7200 ]; then
+    log "no progress, but diagnostic fired <2h ago — skipping"
+    return
+  fi
+
+  log "no progress, no token hints — firing archon-assist diagnostic"
+  echo "$now" > "$stall_marker"
+
+  local logf="/tmp/pipeline-health-diagnostic-$(date +%Y%m%d-%H%M%S).log"
+  (
+    cd "$BASE_DIR/archon"
+    CLAUDECODE=0 nohup archon workflow run archon-assist \
+      "Pipeline-health-cron detected no progress across repos ${REPOS[*]} in the last 30 minutes. No commits landed on origin/main, no archon workflows completed, and no token-limit markers were found in recent .archon-logs. Investigate: check 'gh run list' per repo, 'archon workflow status', recent logs in /tmp/pr-maintenance.log and /tmp/issue-pickup.log, and take action to unblock whatever is stuck." \
+      > "$logf" 2>&1 &
+    disown
+  )
+  # No ntfy — archon-assist has been fired and will diagnose; if nothing
+  # improves on the next tick, we'll fire it again (2h cooldown).
+}
+
+# ----------------------------------------------------------------------------
+log "=== pipeline health check ==="
+for project in "${REPOS[@]}"; do
+  check_main_ci "$project"
+  check_prod_deploy "$project"
+done
+reconcile_zombies
+check_disk
+check_progress
+log "=== done ==="

--- a/ops/cron/pr-review-cron.sh
+++ b/ops/cron/pr-review-cron.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# pr-review-cron.sh — run every 5 minutes from cron.
+# Fires archon-smart-pr-review against non-draft open PRs in managed repos,
+# once per (repo, pr_number, head_sha). Uses the user's Claude.ai subscription
+# auth (same as issue-pickup-cron.sh / pr-maintenance-cron.sh); no Anthropic
+# API key required.
+#
+# Crontab:
+#   */5 * * * * <repo>/ops/cron/pr-review-cron.sh >> /tmp/pr-review.log 2>&1
+#
+# State (per PR):
+#   ~/.archon/state/pr-review/${project}-${pr}.pid          — PID:SHA, in-flight
+#   ~/.archon/state/pr-review/${project}-${pr}-reviewed.sha — last reviewed SHA
+#
+# Flow:
+#   Tick A: PR has no reviewed.sha (or SHA changed) AND no live pid file → fire
+#           archon, write pid file with $!:headSha.
+#   Tick B: pid file exists → if PID still alive skip; if dead read SHA from
+#           pid file, write to reviewed.sha, remove pid file.
+
+set -uo pipefail
+
+# Cron has a minimal PATH; prepend where archon / gh / bun live.
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+# Bail early with a clear log line if a required tool is missing.
+for tool in gh jq archon; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "$(date -Is) [pr-review] FATAL: '$tool' not in PATH ($PATH)" >&2
+    exit 1
+  fi
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/archon-projects.sh
+source "$SCRIPT_DIR/lib/archon-projects.sh"
+load_archon_projects DEFAULT_PROJECTS
+
+BASE_DIR="/mnt/ext-fast"
+STATE_DIR="$HOME/.archon/state/pr-review"
+LOG_PREFIX="[pr-review]"
+mkdir -p "$STATE_DIR"
+
+PROJECTS=("${DEFAULT_PROJECTS[@]}")
+[ $# -gt 0 ] && PROJECTS=("$@")
+
+log() { echo "$(date -Is) $LOG_PREFIX $*"; }
+
+# reap_finished: for this project, sweep any stale pid-files whose PID has
+# exited. When a PID is dead, record the SHA we were reviewing as the
+# "reviewed" SHA so the same head doesn't get re-fired. Best-effort —
+# archon's own logfile captures the actual review result.
+reap_finished() {
+  local project="$1"
+  shopt -s nullglob
+  local pidfile
+  for pidfile in "$STATE_DIR/${project}"-*.pid; do
+    local base pr_num pid sha
+    base=$(basename "$pidfile" .pid)
+    pr_num="${base#${project}-}"
+    # Only accept numeric PR suffix — guards against stray files.
+    [[ "$pr_num" =~ ^[0-9]+$ ]] || continue
+
+    IFS=: read -r pid sha < "$pidfile" 2>/dev/null || continue
+    [ -n "${pid:-}" ] || { rm -f "$pidfile"; continue; }
+
+    if kill -0 "$pid" 2>/dev/null; then
+      continue  # still running
+    fi
+
+    if [ -n "${sha:-}" ]; then
+      echo "$sha" > "$STATE_DIR/${project}-${pr_num}-reviewed.sha"
+      log "$project: PR #$pr_num — archon finished (pid $pid), recorded SHA ${sha:0:10}"
+    else
+      log "$project: PR #$pr_num — archon finished (pid $pid) with no SHA record"
+    fi
+    rm -f "$pidfile"
+  done
+  shopt -u nullglob
+}
+
+# process_project: list open PRs, filter to non-draft, and for each decide
+# whether to skip (already-reviewed / in-flight / running-archon) or fire.
+process_project() {
+  local project="$1"
+  local repo_dir="$BASE_DIR/$project"
+
+  if [ ! -d "$repo_dir/.git" ]; then
+    log "$project: no repo at $repo_dir, skipping"
+    return
+  fi
+
+  local prs_json
+  prs_json=$(gh pr list --repo "alexsiri7/$project" --state open \
+    --json number,headRefOid,isDraft,updatedAt --limit 50 2>/dev/null || echo "[]")
+
+  local n_open n_nondraft
+  n_open=$(echo "$prs_json" | jq 'length' 2>/dev/null || echo 0)
+  n_nondraft=$(echo "$prs_json" | jq '[.[] | select(.isDraft == false)] | length' 2>/dev/null || echo 0)
+
+  local reviewed=0 skipped_running=0 fired=0 in_flight=0
+
+  local rows
+  rows=$(echo "$prs_json" | jq -r '.[] | select(.isDraft == false) | "\(.number) \(.headRefOid)"' 2>/dev/null || true)
+
+  while IFS=' ' read -r pr_num sha; do
+    [ -z "${pr_num:-}" ] && continue
+
+    local pidfile="$STATE_DIR/${project}-${pr_num}.pid"
+    local reviewed_file="$STATE_DIR/${project}-${pr_num}-reviewed.sha"
+
+    # Still-running (reaped above or just fired) → skip
+    if [ -f "$pidfile" ]; then
+      in_flight=$((in_flight + 1))
+      continue
+    fi
+
+    # Already reviewed at this SHA → skip.
+    if [ -f "$reviewed_file" ] && [ "$(cat "$reviewed_file" 2>/dev/null)" = "$sha" ]; then
+      reviewed=$((reviewed + 1))
+      continue
+    fi
+
+    # Dedupe against a live archon process for THIS repo + PR. Anchor on the
+    # project name inside the command line (cd "$repo_dir" puts the project
+    # slug in the process's cwd/command) and on "#$pr_num" to be precise.
+    if pgrep -fa "archon workflow run archon-smart-pr-review" 2>/dev/null \
+         | grep -E "(^|[[:space:]=/])$project([[:space:]/]|\$)" \
+         | grep -qE "#${pr_num}\\b"; then
+      skipped_running=$((skipped_running + 1))
+      continue
+    fi
+
+    # Fire archon.
+    (
+      cd "$repo_dir" || exit 1
+      mkdir -p .archon-logs
+      local logf=".archon-logs/pr-review-${pr_num}-$(date +%Y%m%d-%H%M%S).log"
+      CLAUDECODE=0 nohup archon workflow run archon-smart-pr-review "#${pr_num}" \
+        >"$logf" 2>&1 &
+      disown
+      echo "$!:$sha" > "$STATE_DIR/${project}-${pr_num}.pid"
+      echo "LAUNCHED pid=$! log=$logf"
+    ) > /tmp/.pr-review-fire.$$ 2>&1
+    local fire_rc=$?
+    local fire_out
+    fire_out=$(cat /tmp/.pr-review-fire.$$ 2>/dev/null || true)
+    rm -f /tmp/.pr-review-fire.$$
+    if [ "$fire_rc" -eq 0 ] && echo "$fire_out" | grep -q '^LAUNCHED '; then
+      fired=$((fired + 1))
+      log "$project: PR #$pr_num — fired archon-smart-pr-review at SHA ${sha:0:10} (${fire_out#LAUNCHED })"
+    else
+      log "$project: PR #$pr_num — failed to launch archon: $fire_out"
+    fi
+  done <<< "$rows"
+
+  log "$project: $n_open open, $n_nondraft non-draft, $reviewed reviewed-at-this-SHA, $in_flight in-flight, $skipped_running skipped-running, $fired fired"
+}
+
+for PROJECT in "${PROJECTS[@]}"; do
+  reap_finished "$PROJECT"
+  process_project "$PROJECT"
+done
+
+log "Done"

--- a/workers/feedback/README.md
+++ b/workers/feedback/README.md
@@ -1,0 +1,48 @@
+# feedback worker
+
+Cloudflare Worker that accepts feedback submissions from mobile apps and files
+them as GitHub issues on the allowlisted repos, optionally with a screenshot.
+
+## Why
+
+Mobile apps cannot safely hold a GitHub PAT (it's extractable from the signed
+APK). This worker holds the PAT server-side; clients only know the worker URL.
+
+## API
+
+```
+POST https://<worker>.workers.dev/
+Content-Type: application/json
+
+{
+  "repo": "alexsiri7/un-reminder",      // must be in allowlist
+  "type": "bug" | "feature" | "other",
+  "message": "...",                      // required, ≤10k chars
+  "screenshot": "<base64 or data URL>",  // optional, ≤2MB decoded
+  "context": {
+    "appVersion": "1.2.3",
+    "os": "Android 16",
+    "device": "Pixel 8 Pro"
+  }
+}
+```
+
+Response on success: `201 { success: true, issueUrl, issueNumber }`.
+Errors: `400` invalid body, `403` repo not allowlisted, `502` GitHub API
+failure, `503` worker missing secret.
+
+## Allowlist
+
+Edit `ALLOWED_REPOS` in `src/index.ts` to add a new repo. Redeploy.
+
+## Deploy
+
+CI: push to `main` with changes under `workers/feedback/**` triggers the
+`Deploy feedback worker` workflow. Repo secrets required:
+
+- `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` (already set)
+- `GITHUB_FEEDBACK_TOKEN` — fine-grained PAT with Issues:write on every
+  repo in the allowlist
+
+Manual: `cd workers/feedback && npx wrangler deploy` (after
+`wrangler secret put GITHUB_FEEDBACK_TOKEN`).

--- a/workers/feedback/README.md
+++ b/workers/feedback/README.md
@@ -41,8 +41,8 @@ CI: push to `main` with changes under `workers/feedback/**` triggers the
 `Deploy feedback worker` workflow. Repo secrets required:
 
 - `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` (already set)
-- `GITHUB_FEEDBACK_TOKEN` — fine-grained PAT with Issues:write on every
+- `FEEDBACK_TOKEN` — fine-grained PAT with Issues:write on every
   repo in the allowlist
 
 Manual: `cd workers/feedback && npx wrangler deploy` (after
-`wrangler secret put GITHUB_FEEDBACK_TOKEN`).
+`wrangler secret put FEEDBACK_TOKEN`).

--- a/workers/feedback/package-lock.json
+++ b/workers/feedback/package-lock.json
@@ -1,0 +1,1606 @@
+{
+  "name": "feedback-worker",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "feedback-worker",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250321.0",
+        "typescript": "^5.4.0",
+        "wrangler": "^3.114.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.14",
+        "workerd": "^1.20250124.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260418.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260418.1.tgz",
+      "integrity": "sha512-bywXb2XmeSqrLCQYipcupLneqx015YhhNWz2v9b9iatpe8Cg551vP7ZuD5S2a6GfBka0dDnO70kIBiBvFglcrg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20250718.3",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
+      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "stoppable": "1.1.0",
+        "undici": "^5.28.5",
+        "workerd": "1.20250718.0",
+        "ws": "8.18.0",
+        "youch": "3.3.4",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.1",
+        "ohash": "^2.0.10",
+        "pathe": "^2.0.3",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+        "@cloudflare/workerd-linux-64": "1.20250718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
+        "@cloudflare/workerd-windows-64": "1.20250718.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "3.114.17",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
+      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/unenv-preset": "2.0.2",
+        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20250718.3",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.14",
+        "workerd": "1.20250718.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250408.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/workers/feedback/package.json
+++ b/workers/feedback/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "feedback-worker",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250321.0",
+    "typescript": "^5.4.0",
+    "wrangler": "^3.114.0"
+  }
+}

--- a/workers/feedback/src/index.ts
+++ b/workers/feedback/src/index.ts
@@ -1,0 +1,191 @@
+// Feedback worker — receives feedback submissions from mobile apps and
+// creates a GitHub issue with an optional annotated screenshot.
+//
+// Why this exists: mobile apps cannot hold a GitHub PAT safely (it would be
+// extractable from the signed APK). This worker holds the PAT server-side
+// and exposes a narrow API: create an issue on one of the allowlisted repos,
+// optionally with a screenshot attachment, and nothing else.
+//
+// Allowlist is baked in — clients cannot submit to arbitrary repos.
+
+interface Env {
+  GITHUB_FEEDBACK_TOKEN: string;
+}
+
+const ALLOWED_REPOS = new Set<string>([
+  "alexsiri7/un-reminder",
+  "alexsiri7/cosmic-match",
+]);
+
+const LABEL_MAP: Record<string, string> = {
+  bug: "bug",
+  feature: "enhancement",
+  other: "feedback",
+};
+
+const MAX_SCREENSHOT_BYTES = 2 * 1024 * 1024;
+const MAX_MESSAGE_CHARS = 10_000;
+
+interface FeedbackBody {
+  repo: string;
+  type: "bug" | "feature" | "other";
+  message: string;
+  screenshot?: string;
+  context?: {
+    appVersion?: string;
+    device?: string;
+    os?: string;
+  };
+}
+
+const CORS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Max-Age": "86400",
+};
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...CORS },
+  });
+}
+
+function escapeMd(s: string): string {
+  return s.replace(/[<>`]/g, (c) => `\\${c}`);
+}
+
+async function getRepoId(token: string, repo: string): Promise<string> {
+  const res = await fetch(`https://api.github.com/repos/${repo}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "feedback-worker",
+    },
+  });
+  if (!res.ok) throw new Error(`repo lookup failed: ${res.status}`);
+  const data = (await res.json()) as { id: number };
+  return String(data.id);
+}
+
+async function uploadScreenshot(
+  token: string,
+  repo: string,
+  dataUrl: string,
+): Promise<string | null> {
+  const base64 = dataUrl.includes(",") ? dataUrl.split(",")[1] : dataUrl;
+  if (!base64) return null;
+
+  const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  if (bytes.length > MAX_SCREENSHOT_BYTES) return null;
+
+  const blob = new Blob([bytes], { type: "image/png" });
+  const form = new FormData();
+  form.append("file", blob, `feedback-${Date.now()}.png`);
+  form.append("repository_id", await getRepoId(token, repo));
+  form.append("authenticity_token", token);
+
+  const res = await fetch(
+    `https://uploads.github.com/repos/${repo}/issues/uploads`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "User-Agent": "feedback-worker",
+      },
+      body: form,
+    },
+  );
+  if (!res.ok) return null;
+  const data = (await res.json()) as {
+    href?: string;
+    asset?: { href?: string };
+  };
+  return data.href || data.asset?.href || null;
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    if (req.method === "OPTIONS")
+      return new Response(null, { headers: CORS });
+    if (req.method !== "POST")
+      return json({ error: "method not allowed" }, 405);
+
+    let body: FeedbackBody;
+    try {
+      body = (await req.json()) as FeedbackBody;
+    } catch {
+      return json({ error: "invalid JSON" }, 400);
+    }
+
+    if (!ALLOWED_REPOS.has(body.repo))
+      return json({ error: "repo not allowed" }, 403);
+    if (!body.type || !(body.type in LABEL_MAP))
+      return json({ error: "invalid type" }, 400);
+    if (!body.message?.trim())
+      return json({ error: "message required" }, 400);
+    if (body.message.length > MAX_MESSAGE_CHARS)
+      return json({ error: "message too long" }, 400);
+
+    const token = env.GITHUB_FEEDBACK_TOKEN;
+    if (!token) return json({ error: "worker not configured" }, 503);
+
+    let screenshotUrl: string | null = null;
+    if (body.screenshot) {
+      try {
+        screenshotUrl = await uploadScreenshot(token, body.repo, body.screenshot);
+      } catch {
+        screenshotUrl = null;
+      }
+    }
+
+    const msg = body.message.trim();
+    const parts: string[] = [msg];
+    if (screenshotUrl) {
+      parts.push("", "### Screenshot", `![screenshot](${screenshotUrl})`);
+    }
+    if (body.context) {
+      const ctx: string[] = [];
+      if (body.context.appVersion)
+        ctx.push(`**App version:** ${escapeMd(body.context.appVersion)}`);
+      if (body.context.os) ctx.push(`**OS:** ${escapeMd(body.context.os)}`);
+      if (body.context.device)
+        ctx.push(`**Device:** ${escapeMd(body.context.device)}`);
+      if (ctx.length) parts.push("", "---", "### Context", ...ctx);
+    }
+
+    const typePrefix =
+      body.type === "bug" ? "Bug: " : body.type === "feature" ? "Feature: " : "";
+    const titleSnippet = msg.split("\n")[0].slice(0, 80);
+    const title = `${typePrefix}${titleSnippet}`;
+    const labels = [LABEL_MAP[body.type]];
+
+    const issueRes = await fetch(
+      `https://api.github.com/repos/${body.repo}/issues`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "Content-Type": "application/json",
+          "User-Agent": "feedback-worker",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        body: JSON.stringify({ title, body: parts.join("\n"), labels }),
+      },
+    );
+
+    if (!issueRes.ok) return json({ error: "failed to create issue" }, 502);
+
+    const issue = (await issueRes.json()) as {
+      html_url: string;
+      number: number;
+    };
+    return json(
+      { success: true, issueUrl: issue.html_url, issueNumber: issue.number },
+      201,
+    );
+  },
+};

--- a/workers/feedback/src/index.ts
+++ b/workers/feedback/src/index.ts
@@ -9,7 +9,7 @@
 // Allowlist is baked in — clients cannot submit to arbitrary repos.
 
 interface Env {
-  GITHUB_FEEDBACK_TOKEN: string;
+  FEEDBACK_TOKEN: string;
 }
 
 const ALLOWED_REPOS = new Set<string>([
@@ -129,7 +129,7 @@ export default {
     if (body.message.length > MAX_MESSAGE_CHARS)
       return json({ error: "message too long" }, 400);
 
-    const token = env.GITHUB_FEEDBACK_TOKEN;
+    const token = env.FEEDBACK_TOKEN;
     if (!token) return json({ error: "worker not configured" }, 503);
 
     let screenshotUrl: string | null = null;

--- a/workers/feedback/tsconfig.json
+++ b/workers/feedback/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workers/feedback/wrangler.toml
+++ b/workers/feedback/wrangler.toml
@@ -1,0 +1,7 @@
+name = "feedback"
+main = "src/index.ts"
+compatibility_date = "2026-04-18"
+
+# Secrets (set via CI or `wrangler secret put`):
+#   GITHUB_FEEDBACK_TOKEN — fine-grained PAT with Issues:write on
+#                           alexsiri7/un-reminder and alexsiri7/cosmic-match

--- a/workers/feedback/wrangler.toml
+++ b/workers/feedback/wrangler.toml
@@ -3,5 +3,5 @@ main = "src/index.ts"
 compatibility_date = "2026-04-18"
 
 # Secrets (set via CI or `wrangler secret put`):
-#   GITHUB_FEEDBACK_TOKEN — fine-grained PAT with Issues:write on
+#   FEEDBACK_TOKEN — fine-grained PAT with Issues:write on
 #                           alexsiri7/un-reminder and alexsiri7/cosmic-match


### PR DESCRIPTION
## Summary
- Moves the archon-pipeline crontab scripts from a local-only `~/gt/mayor/scripts/` tree into this repo under `ops/cron/` so they're versioned and backed up.
- Externalizes secrets (three Supabase DB URLs + ntfy topic) to `~/.config/archon-cron/secrets.env`; scripts fail loud if missing. No hardcoded prod creds in-tree.
- Makes all internal `source`/`lib` references portable via `SCRIPT_DIR` pattern.
- Adds `ops/cron/README.md` + a committed `ops/cron/crontab` reference file.

## Test plan
- [x] `bash -n` on every script — syntax clean.
- [x] `source lib/archon-projects.sh && load_archon_projects FOO` works from new location.
- [x] `source secrets.env` populates all 4 expected vars.
- [x] `git diff --cached` grep for `postgres://…@`, `hpkupxaoxsh…`, `gascity-alexsiri7` → zero hits.
- [ ] Post-merge: update live crontab + observe one tick of `issue-pickup-cron` + `pr-review-cron`.

Note: `pr-maintenance-cron.sh` is not included — it still lives in `/mnt/ext-fast/archon/scripts/` (a separate real repo). That's intentional.