### PR TITLE
ops: dep-aware issue pickup + move pr-maintenance-cron

### DIFF
--- a/ops/cron/README.md
+++ b/ops/cron/README.md
@@ -38,7 +38,8 @@ It installs with absolute paths pointing at `/mnt/ext-fast/interstellarai.net/op
 
 | Script | Cadence | What it does |
 |---|---|---|
-| `issue-pickup-cron.sh` | every 15 min | auto-label new issues, fire `archon-fix-github-issue` on oldest queued |
+| `issue-pickup-cron.sh` | every 15 min | auto-label new issues, fire `archon-fix-github-issue` on oldest queued (dep-aware: skips issues with open blockers) |
+| `pr-maintenance-cron.sh` | every 15 min | zero-AI PR janitor: promotes green drafts, squash-merges CLEAN, fires `archon-pr-maintenance` on one dirty/behind PR per project |
 | `pr-review-cron.sh` | every 5 min | fire `archon-smart-pr-review` on open non-draft PRs, once per (repo, pr, sha) |
 | `pipeline-health-cron.sh` | every 30 min | main-CI-red detection, zombie-run reaping, disk pressure, stall detection |
 | `backup-dbs.sh` | every 3h (at :17) | Supabase → local + rclone to Google Drive |
@@ -50,4 +51,3 @@ It installs with absolute paths pointing at `/mnt/ext-fast/interstellarai.net/op
 | `lib/archon-projects.sh` | sourced by others | loads project list from `archon-projects.txt` |
 | `archon-projects.txt` | data | canonical list of managed project slugs under `alexsiri7/` |
 
-Note: `pr-maintenance-cron.sh` lives separately in the `archon` repo (`/mnt/ext-fast/archon/scripts/`). It's in the installed crontab but not versioned here.

--- a/ops/cron/crontab
+++ b/ops/cron/crontab
@@ -3,7 +3,7 @@
 # Secrets loaded from ~/.config/archon-cron/secrets.env (not in this repo).
 
 */15 * * * * /mnt/ext-fast/interstellarai.net/ops/cron/issue-pickup-cron.sh >> /tmp/issue-pickup.log 2>&1
-*/15 * * * * /mnt/ext-fast/archon/scripts/pr-maintenance-cron.sh >> /tmp/pr-maintenance.log 2>&1
+*/15 * * * * /mnt/ext-fast/interstellarai.net/ops/cron/pr-maintenance-cron.sh >> /tmp/pr-maintenance.log 2>&1
 17 */3 * * * /mnt/ext-fast/interstellarai.net/ops/cron/backup-dbs.sh >> /tmp/db-backup.log 2>&1
 */30 * * * * /mnt/ext-fast/interstellarai.net/ops/cron/pipeline-health-cron.sh >> /tmp/pipeline-health.log 2>&1
 0 8 * * * /mnt/ext-fast/interstellarai.net/ops/cron/daily-release-cron.sh >> /tmp/daily-release.log 2>&1

--- a/ops/cron/issue-pickup-cron.sh
+++ b/ops/cron/issue-pickup-cron.sh
@@ -28,7 +28,7 @@ LOG_PREFIX="[issue-pickup]"
 INGEST_LABELS=("enhancement" "bug")
 
 # Labels archon already manages — presence of any of these means "don't re-queue".
-ARCHON_LABELS=("archon:queued" "archon:in-progress" "archon:done" "archon:failed" "archon:skipped")
+ARCHON_LABELS=("archon:queued" "archon:in-progress" "archon:done" "archon:failed" "archon:skipped" "archon:blocked")
 
 PROJECTS=("${DEFAULT_PROJECTS[@]}")
 [ $# -gt 0 ] && PROJECTS=("$@")
@@ -40,15 +40,29 @@ log() { echo "$(date -Is) $LOG_PREFIX $*"; }
 SUMMARY_IN_PROGRESS=0
 SUMMARY_STALE=0
 SUMMARY_QUEUED=0
+SUMMARY_BLOCKED=0
+SUMMARY_PROMOTED=0
 SUMMARY_ACTION="none"
 SUMMARY_NOTE=""
 
 ensure_labels() {
   local repo="$1"
-  for label in archon:queued archon:in-progress archon:done archon:failed archon:skipped; do
+  for label in archon:queued archon:in-progress archon:done archon:failed archon:skipped archon:blocked; do
     gh label create "$label" --repo "alexsiri7/$repo" \
       --color "c2e0c6" --description "Archon pipeline state" 2>/dev/null || true
   done
+}
+
+# Returns 0 (blocked) if the issue has at least one open dependency, 1 (clear)
+# otherwise. Uses GitHub's issue dependencies API. On API error, defaults to
+# "clear" — we'd rather let a candidate run than freeze the pipeline on a
+# transient failure; the worst case is a phase runs slightly out of order.
+has_open_blockers() {
+  local project="$1" issue_num="$2"
+  local blockers
+  blockers=$(gh api "repos/alexsiri7/$project/issues/$issue_num/dependencies/blocked_by" \
+    --jq '[.[] | select(.state == "open")] | length' 2>/dev/null || echo 0)
+  [ "${blockers:-0}" -gt 0 ]
 }
 
 has_archon_label() {
@@ -156,9 +170,47 @@ auto_queue() {
     local age=$((now_sec - created_sec))
     [ "$age" -lt 300 ] && continue
 
-    log "$project: auto-queuing #$num (age ${age}s)"
-    gh issue edit "$num" --repo "alexsiri7/$project" --add-label "archon:queued" 2>/dev/null || \
-      log "$project: #$num — could not add archon:queued label"
+    # Dep-aware: if the issue has open blockers, park it in archon:blocked
+    # instead of archon:queued. promote_unblocked will flip it later.
+    local initial_label="archon:queued"
+    if has_open_blockers "$project" "$num"; then
+      initial_label="archon:blocked"
+      log "$project: auto-labeling #$num archon:blocked (open blockers)"
+    else
+      log "$project: auto-queuing #$num (age ${age}s)"
+    fi
+    gh issue edit "$num" --repo "alexsiri7/$project" --add-label "$initial_label" 2>/dev/null || \
+      log "$project: #$num — could not add $initial_label label"
+  done
+}
+
+# --- Phase 1.5: promote archon:blocked issues whose blockers are all closed ---
+# Runs after auto_queue so newly-filed sub-issues that happen to be unblocked
+# get picked up on the same tick.
+promote_unblocked() {
+  local project="$1"
+  local blocked_json
+  blocked_json=$(gh issue list --repo "alexsiri7/$project" --state open \
+    --label "archon:blocked" --limit 100 --json number 2>/dev/null || echo "[]")
+  SUMMARY_BLOCKED=$(echo "$blocked_json" | jq 'length' 2>/dev/null || echo 0)
+
+  local nums
+  nums=$(echo "$blocked_json" | jq -r '.[].number' 2>/dev/null)
+  [ -z "$nums" ] && return
+
+  local num
+  for num in $nums; do
+    if has_open_blockers "$project" "$num"; then
+      continue
+    fi
+    log "$project: #$num unblocked — promoting archon:blocked → archon:queued"
+    if gh issue edit "$num" --repo "alexsiri7/$project" \
+        --remove-label "archon:blocked" --add-label "archon:queued" 2>/dev/null; then
+      SUMMARY_PROMOTED=$((SUMMARY_PROMOTED + 1))
+      SUMMARY_BLOCKED=$((SUMMARY_BLOCKED - 1))
+    else
+      log "$project: #$num — could not swap blocked→queued"
+    fi
   done
 }
 
@@ -234,9 +286,10 @@ for PROJECT in "${PROJECTS[@]}"; do
   ensure_labels "$PROJECT"
   unstick_stale "$PROJECT"
   auto_queue "$PROJECT"
+  promote_unblocked "$PROJECT"
   pick_and_fire "$PROJECT"
 
-  summary="$PROJECT: queued=$SUMMARY_QUEUED in-progress=$SUMMARY_IN_PROGRESS stale=$SUMMARY_STALE action=$SUMMARY_ACTION"
+  summary="$PROJECT: queued=$SUMMARY_QUEUED blocked=$SUMMARY_BLOCKED in-progress=$SUMMARY_IN_PROGRESS stale=$SUMMARY_STALE promoted=$SUMMARY_PROMOTED action=$SUMMARY_ACTION"
   [ -n "$SUMMARY_NOTE" ] && summary="$summary ($SUMMARY_NOTE)"
   log "$summary"
 done

--- a/ops/cron/pr-maintenance-cron.sh
+++ b/ops/cron/pr-maintenance-cron.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# pr-maintenance-cron.sh — Run from cron every 15 minutes.
+# Zero AI cost when nothing to do. Processes one PR per project per run.
+#
+# Usage:
+#   ./scripts/pr-maintenance-cron.sh                    # all projects
+#   ./scripts/pr-maintenance-cron.sh cosmic-match reli  # specific projects
+#
+# Crontab entry:
+#   */15 * * * * <repo>/ops/cron/pr-maintenance-cron.sh >> /tmp/pr-maintenance.log 2>&1
+
+set -euo pipefail
+
+# Cron runs with a minimal PATH (/usr/bin:/bin). archon, gh, bun, git
+# often live in user-local bins; prepend them so the script works from
+# both cron and an interactive shell.
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+# --- Configuration ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/archon-projects.sh
+source "$SCRIPT_DIR/lib/archon-projects.sh"
+load_archon_projects DEFAULT_PROJECTS
+BASE_DIR="/mnt/ext-fast"
+LOG_PREFIX="[pr-maintenance]"
+
+# Use arguments if provided, otherwise all projects
+if [ $# -gt 0 ]; then
+  PROJECTS=("$@")
+else
+  PROJECTS=("${DEFAULT_PROJECTS[@]}")
+fi
+
+log() { echo "$(date -Is) $LOG_PREFIX $*"; }
+
+for PROJECT in "${PROJECTS[@]}"; do
+  REPO_DIR="$BASE_DIR/$PROJECT"
+
+  if [ ! -d "$REPO_DIR/.git" ]; then
+    log "$PROJECT: not a git repo, skipping"
+    continue
+  fi
+
+  cd "$REPO_DIR"
+
+  # --- Phase 0: Promote CLEAN draft PRs to ready-for-review ---
+  # Archon workflows create PRs as drafts by default. When CI is green the
+  # draft has nothing left to gate on, but the Phase 1 merge filter skips
+  # drafts — so left alone a green draft sits forever. Flip it to ready so
+  # Phase 1 can merge it on this same tick.
+  GREEN_DRAFTS=$(gh pr list --state open --json number,mergeStateStatus,isDraft \
+    --jq '[.[] | select(.isDraft == true and .mergeStateStatus == "CLEAN")] | .[].number' 2>/dev/null || true)
+
+  for PR in $GREEN_DRAFTS; do
+    log "$PROJECT: promoting draft PR #$PR to ready (CI CLEAN)"
+    if ! gh pr ready "$PR" 2>>"/tmp/pr-maintenance-errors.log"; then
+      log "$PROJECT: PR #$PR — could not mark ready (see /tmp/pr-maintenance-errors.log)"
+    fi
+  done
+
+  # --- Phase 1: Merge CLEAN PRs directly (bash only, zero AI cost) ---
+  CLEAN_PRS=$(gh pr list --state open --json number,mergeStateStatus,isDraft \
+    --jq '[.[] | select(.isDraft == false and .mergeStateStatus == "CLEAN")] | .[].number' 2>/dev/null || true)
+
+  for PR in $CLEAN_PRS; do
+    log "$PROJECT: PR #$PR is CLEAN — merging directly"
+    # Surface stderr to the cron log so actual failures (permissions, branch
+    # protection, etc.) are diagnosable on the next tick instead of vanishing.
+    if ! gh pr merge "$PR" --squash --auto --delete-branch 2>&1; then
+      if ! gh pr merge "$PR" --squash --delete-branch 2>&1; then
+        log "$PROJECT: PR #$PR — could not merge, skipping"
+      fi
+    fi
+  done
+
+  # --- Phase 2: Check for one PR needing AI attention ---
+  ACTIONABLE=$(gh pr list --state open --json number,mergeStateStatus,isDraft \
+    --jq '[.[] | select(.isDraft == false and (.mergeStateStatus == "BEHIND" or .mergeStateStatus == "DIRTY" or .mergeStateStatus == "UNSTABLE" or .mergeStateStatus == "UNKNOWN"))] | .[0].number // empty' 2>/dev/null || true)
+
+  if [ -z "$ACTIONABLE" ]; then
+    log "$PROJECT: no PRs need AI maintenance"
+    continue
+  fi
+
+  log "$PROJECT: PR #$ACTIONABLE needs maintenance — launching archon"
+  archon workflow run archon-pr-maintenance --cwd "$REPO_DIR" "PR #$ACTIONABLE" &
+
+done
+
+# Wait for any background archon runs to complete
+wait
+log "Done"


### PR DESCRIPTION
## Summary

- **`issue-pickup-cron.sh`** now queries `/repos/:o/:r/issues/:n/dependencies/blocked_by` before queueing an issue. If any blocker is open, the issue gets `archon:blocked` instead of `archon:queued`. A new `promote_unblocked` pass (runs between `auto_queue` and `pick_and_fire` each tick) flips `blocked → queued` when every blocker is closed. This enables multi-phase PRDs via GitHub's native sub-issue + issue-dependency relationships — no body parsing, no custom state store.
- **`pr-maintenance-cron.sh`** moves in from `archon/scripts/`. It was never archon-native — it's a cron that calls archon workflows. The old copy also sourced a now-dead `gt/mayor` path, so this also fixes a latent bug. A follow-up PR on `archon` will delete the original.

## Test plan
- [x] `bash -n` clean on both modified scripts.
- [x] Lib loads from new location: `source lib/archon-projects.sh && load_archon_projects FOO` → 6 projects.
- [x] Dep-check helper smoke: `has_open_blockers un-reminder 66` → clear (no blockers set yet, correct).
- [x] Dry run of whole script (by sourcing) — no side effects, new `blocked=` / `promoted=` counters in summary line.
- [ ] Post-merge: update crontab, observe one full tick of `issue-pickup` across all 6 projects.

## Fallback behaviour

If the dependencies API errors (network blip, permission change, etc.), `has_open_blockers` defaults to "clear". We'd rather let a phase run slightly out of order than freeze the whole pipeline on a transient failure.