### PR TITLE
ops: treat open sub-issues as blockers in issue-pickup

### DIFF
--- a/ops/cron/README.md
+++ b/ops/cron/README.md
@@ -38,7 +38,7 @@ It installs with absolute paths pointing at `/mnt/ext-fast/interstellarai.net/op
 
 | Script | Cadence | What it does |
 |---|---|---|
-| `issue-pickup-cron.sh` | every 15 min | auto-label new issues, fire `archon-fix-github-issue` on oldest queued (dep-aware: skips issues with open blockers) |
+| `issue-pickup-cron.sh` | every 15 min | auto-label new issues, fire `archon-fix-github-issue` on oldest queued. Dep-aware: an issue is blocked if it has any open `blocked_by` dep OR any open sub-issue child (so PRDs park themselves until all phases close, then unblock for finalization). |
 | `pr-maintenance-cron.sh` | every 15 min | zero-AI PR janitor: promotes green drafts, squash-merges CLEAN, fires `archon-pr-maintenance` on one dirty/behind PR per project |
 | `pr-review-cron.sh` | every 5 min | fire `archon-smart-pr-review` on open non-draft PRs, once per (repo, pr, sha) |
 | `pipeline-health-cron.sh` | every 30 min | main-CI-red detection, zombie-run reaping, disk pressure, stall detection |

--- a/ops/cron/issue-pickup-cron.sh
+++ b/ops/cron/issue-pickup-cron.sh
@@ -53,16 +53,29 @@ ensure_labels() {
   done
 }
 
-# Returns 0 (blocked) if the issue has at least one open dependency, 1 (clear)
-# otherwise. Uses GitHub's issue dependencies API. On API error, defaults to
-# "clear" — we'd rather let a candidate run than freeze the pipeline on a
-# transient failure; the worst case is a phase runs slightly out of order.
+# Returns 0 (blocked) if the issue has at least one open "blocker" — defined
+# as either an explicit `blocked_by` dependency OR an open sub-issue (child).
+# Returns 1 (clear) otherwise.
+#
+# The child rule lets PRD/epic issues naturally park themselves while their
+# phase children are in flight — no archon:skipped hygiene needed. When the
+# last child closes, the PRD unblocks and gets picked up, which triggers a
+# finalization archon run over the completed work.
+#
+# On API error, defaults to "clear" — we'd rather let a candidate run than
+# freeze the pipeline on a transient failure; worst case is a phase runs
+# slightly out of order.
 has_open_blockers() {
   local project="$1" issue_num="$2"
-  local blockers
+  local blockers children
   blockers=$(gh api "repos/alexsiri7/$project/issues/$issue_num/dependencies/blocked_by" \
     --jq '[.[] | select(.state == "open")] | length' 2>/dev/null || echo 0)
-  [ "${blockers:-0}" -gt 0 ]
+  if [ "${blockers:-0}" -gt 0 ]; then
+    return 0
+  fi
+  children=$(gh api "repos/alexsiri7/$project/issues/$issue_num/sub_issues" \
+    --jq '[.[] | select(.state == "open")] | length' 2>/dev/null || echo 0)
+  [ "${children:-0}" -gt 0 ]
 }
 
 has_archon_label() {


### PR DESCRIPTION
## Summary
Extends \`has_open_blockers\` in \`ops/cron/issue-pickup-cron.sh\` to also treat any **open sub-issue (child)** as a blocker, not just explicit \`blocked_by\` edges.

## Why
Today a PRD issue (like un-reminder #66) with \`enhancement\` label and no explicit \`blocked_by\` gets auto-queued — the cron treats it like any other work item and fires archon-fix-github-issue on the whole design doc. That's what happened earlier today: #66 got picked up, archon tried to \"fix\" the entire 7-phase pivot as one PR, produced a duplicate Phase 1 implementation (#69), and burned API budget.

With this change, a parent issue with any open sub-issue is blocked by definition. Factory behaviour:

| State | Parent (PRD) behaviour |
|---|---|
| Phase children still open | Parent stays \`archon:blocked\` — cron skips it |
| Last phase closes | Parent unblocks, gets \`archon:queued\`, archon runs once for finalization/validation |

No \`archon:skipped\` hygiene needed on PRDs. The PRD auto-runs as a final validation pass instead of needing a manual close-out.

## Test
- [x] Syntax clean.
- [x] Live probe on un-reminder: \`has_open_blockers 66\` → blocked (5 open children). \`has_open_blockers 71\` → clear. \`has_open_blockers 72\` → blocked (blocked_by #71). \`has_open_blockers 75\` → clear. All correct.

## Fallback
API error → defaults to \"clear\" (same as before — transient failures don't freeze the pipeline).