### PR TITLE
ops: fold poll-health checks + poll-sweep into ops/cron

### DIFF
--- a/ops/cron/README.md
+++ b/ops/cron/README.md
@@ -41,7 +41,8 @@ It installs with absolute paths pointing at `/mnt/ext-fast/interstellarai.net/op
 | `issue-pickup-cron.sh` | every 15 min | auto-label new issues, fire `archon-fix-github-issue` on oldest queued. Dep-aware: an issue is blocked if it has any open `blocked_by` dep OR any open sub-issue child (so PRDs park themselves until all phases close, then unblock for finalization). |
 | `pr-maintenance-cron.sh` | every 15 min | zero-AI PR janitor: promotes green drafts, squash-merges CLEAN, fires `archon-pr-maintenance` on one dirty/behind PR per project |
 | `pr-review-cron.sh` | every 5 min | fire `archon-smart-pr-review` on open non-draft PRs, once per (repo, pr, sha) |
-| `pipeline-health-cron.sh` | every 30 min | main-CI-red detection, zombie-run reaping, disk pressure, stall detection |
+| `pipeline-health-cron.sh` | every 30 min | main-CI-red detection, prod-deploy health (status API + HTTP probe), zombie-run reaping, disk pressure, stall detection, PR-CI retry (fires `archon-assist` on open archon PRs with failed CI), shipped-PR ntfys for merged PRs that closed issues |
+| `sweep-audits.sh` | 02:00 daily | rotating codebase audit (12-slot day-of-year rotation: `archon-architect` / `archon-security-audit` / `archon-test-audit` × filmduel / word-coach-annie / reli / cosmic-match) |
 | `backup-dbs.sh` | every 3h (at :17) | Supabase → local + rclone to Google Drive |
 | `daily-release-cron.sh` | 08:00 daily | tag + release per repo if main moved since last release |
 | `auto-apk-sync.sh` | every 5 min | pull latest signed APK from CI, install to any connected device |

--- a/ops/cron/crontab
+++ b/ops/cron/crontab
@@ -10,3 +10,4 @@
 */5 * * * * /mnt/ext-fast/interstellarai.net/ops/cron/auto-apk-sync.sh >> /tmp/apk-sync.log 2>&1
 7 * * * * /usr/sbin/logrotate --state /home/asiri/.logrotate.state /home/asiri/.config/logrotate/archon-pipeline.conf >/dev/null 2>&1
 */5 * * * * /mnt/ext-fast/interstellarai.net/ops/cron/pr-review-cron.sh >> /tmp/pr-review.log 2>&1
+0 2 * * * /mnt/ext-fast/interstellarai.net/ops/cron/sweep-audits.sh >> /tmp/sweep-audits.log 2>&1

--- a/ops/cron/pipeline-health-cron.sh
+++ b/ops/cron/pipeline-health-cron.sh
@@ -8,6 +8,13 @@
 #   5. No pipeline progress in last tick (no commits, no archon completions):
 #        - If token-limit markers in recent logs → wait, retry next tick
 #        - Else → fire archon-assist diagnostic (dedup: 2h cooldown)
+#   6. Open archon PRs with failed CI → fire archon-assist to diagnose + fix
+#      (dedup by PR number, reset when PR merges/closes)
+#   7. Prod deploy HTTP health → file bug issue if deploy URL returns non-2xx/3xx
+#      (dedup per-project, cleared on recovery)
+#   8. Shipped-PR ntfy → emit "Shipped: repo #issue" for PRs that closed issues
+#      in the last 24h, when the deploy URL is currently healthy
+#      (dedup per-PR)
 #
 # Crontab:
 #   */30 * * * * <repo>/ops/cron/pipeline-health-cron.sh >> /tmp/pipeline-health.log 2>&1
@@ -29,6 +36,16 @@ SECRETS_FILE="${ARCHON_CRON_SECRETS:-$HOME/.config/archon-cron/secrets.env}"
 [ -r "$SECRETS_FILE" ] && . "$SECRETS_FILE"
 : "${NTFY_TOPIC:?NTFY_TOPIC not set — populate $SECRETS_FILE}"
 LOG_PREFIX="[pipeline-health]"
+
+# Public prod-deploy URLs, keyed by project slug. Only projects listed here
+# are subject to HTTP health checks + shipped-PR ntfys. Keep in sync with
+# deploy workflows / ntfy steps in each repo's .github/workflows/.
+declare -A DEPLOY_URLS=(
+  ["filmduel"]="https://filmduel.up.railway.app"
+  ["word-coach-annie"]="https://annie.interstellarai.net/api/health"
+  ["reli"]="https://reli.interstellarai.net"
+  ["interstellarai.net"]="https://www.interstellarai.net"
+)
 
 mkdir -p "$STATE_DIR"
 
@@ -432,10 +449,184 @@ check_progress() {
 }
 
 # ----------------------------------------------------------------------------
+# Check 5: Retry CI on open archon PRs with failed checks.
+#   Ported from archon/scripts/poll-health.sh (check 1). For each open PR on
+#   an `archon/` branch whose statusCheckRollup contains a FAILURE, fire
+#   archon-assist to diagnose + push a fix. Dedup by PR number; cleared when
+#   the PR is no longer in the failed-CI list (merged, closed, or recovered).
+# ----------------------------------------------------------------------------
+check_pr_ci_retry() {
+  local project="$1"
+  local repo_dir="$BASE_DIR/$project"
+  [ -d "$repo_dir/.git" ] || return
+
+  # Collect current set of archon PRs with FAILURE in rollup
+  local failed_prs
+  failed_prs=$(gh pr list --repo "alexsiri7/$project" --state open \
+    --json number,title,headRefName,statusCheckRollup \
+    --jq '.[] | select(.headRefName | startswith("archon/")) | select(.statusCheckRollup | length > 0) | select(.statusCheckRollup | map(.conclusion // "PENDING") | any(. == "FAILURE")) | [(.number|tostring), .title] | @tsv' \
+    2>/dev/null || echo "")
+
+  # Clear markers for PRs no longer failing
+  local current_nums=""
+  if [ -n "$failed_prs" ]; then
+    current_nums=$(echo "$failed_prs" | awk -F'\t' '{print $1}' | sort -u)
+  fi
+  local prefix="prciretry-$project-pr"
+  while IFS= read -r marker; do
+    [ -z "$marker" ] && continue
+    local mbase mnum
+    mbase=$(basename "$marker")
+    mnum="${mbase#$prefix}"
+    if [ -z "$current_nums" ] || ! echo "$current_nums" | grep -qx "$mnum"; then
+      rm -f "$marker"
+    fi
+  done < <(find "$STATE_DIR" -maxdepth 1 -name "prciretry-$project-pr*" 2>/dev/null)
+
+  [ -n "$failed_prs" ] || return
+
+  while IFS=$'\t' read -r pr_num pr_title; do
+    [ -n "$pr_num" ] || continue
+    local marker="$STATE_DIR/prciretry-$project-pr$pr_num"
+    if [ -f "$marker" ]; then
+      log "$project: PR #$pr_num CI still red — archon-assist already fired, skipping"
+      continue
+    fi
+
+    log "$project: PR #$pr_num CI red — firing archon-assist to fix"
+    touch "$marker"
+
+    mkdir -p "$repo_dir/.archon-logs"
+    local logf="$repo_dir/.archon-logs/health-pr-ci-fix-pr${pr_num}-$(date +%Y%m%d-%H%M%S).log"
+    (
+      cd "$repo_dir"
+      CLAUDECODE=0 nohup archon workflow run archon-assist \
+        "PR #$pr_num has failing CI checks. Check out the branch, look at the CI failure logs with 'gh pr checks $pr_num' and 'gh run view', diagnose the failure, fix it, commit, and push. The PR title is: $pr_title" \
+        > "$logf" 2>&1 &
+      disown
+    )
+  done <<< "$failed_prs"
+}
+
+# ----------------------------------------------------------------------------
+# Check 6: Prod deploy HTTP health.
+#   Ported from archon/scripts/poll-health.sh (check 3). For each project with
+#   a DEPLOY_URLS entry, HEAD the URL; if HTTP status is <200 or >=400, file
+#   a `bug` issue (queued for the normal pickup cron). Dedup per project;
+#   marker is cleared once the deploy recovers.
+# ----------------------------------------------------------------------------
+check_deploy_http() {
+  local project="$1"
+  local deploy_url="${DEPLOY_URLS[$project]:-}"
+  [ -n "$deploy_url" ] || return  # No public URL configured — skip
+
+  local http_code
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$deploy_url" 2>/dev/null || echo "000")
+
+  local marker="$STATE_DIR/deploy-down-$project"
+  if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 400 ]; then
+    if [ -f "$marker" ]; then
+      log "$project: deploy still down (HTTP $http_code at $deploy_url) — issue already filed, skipping"
+      return
+    fi
+
+    log "$project: deploy down (HTTP $http_code at $deploy_url) — filing issue"
+    touch "$marker"
+
+    local body
+    body=$(cat <<EOF
+## Deploy health check failure
+
+**URL**: $deploy_url
+**HTTP status**: $http_code
+**Detected**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+
+The production deployment is not responding correctly. Check the hosting
+dashboard (Railway / Cloudflare Pages / etc.) and recent deployments for errors.
+EOF
+)
+    gh issue create --repo "alexsiri7/$project" \
+      --title "Deploy down: $deploy_url returning HTTP $http_code" \
+      --label "bug" \
+      --body "$body" >/dev/null 2>&1 || true
+    return
+  fi
+
+  # Healthy — clear marker if present
+  [ -f "$marker" ] && rm -f "$marker"
+  log "$project: deploy OK (HTTP $http_code at $deploy_url)"
+}
+
+# ----------------------------------------------------------------------------
+# Check 7: Shipped-PR ntfy — announce PRs merged in the last 24h.
+#   Ported from archon/scripts/poll-health.sh (check 4). Only fires when the
+#   deploy URL is configured AND currently healthy (we assume merged code is
+#   live). For each merged PR, pulls linked issue numbers from the body and
+#   emits "Shipped: <repo> #<issue>" for each. Dedup per-PR.
+#   Projects without a DEPLOY_URLS entry are skipped (no live signal).
+# ----------------------------------------------------------------------------
+check_shipped_prs() {
+  local project="$1"
+  local deploy_url="${DEPLOY_URLS[$project]:-}"
+  [ -n "$deploy_url" ] || return
+
+  # Only announce if deploy is currently healthy — avoid claiming "shipped"
+  # when prod is actually down. check_deploy_http already logged status.
+  local http_code
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$deploy_url" 2>/dev/null || echo "000")
+  [ "$http_code" -ge 200 ] && [ "$http_code" -lt 400 ] || return
+
+  local merged
+  merged=$(gh pr list --repo "alexsiri7/$project" --state merged \
+    --json number,title,mergedAt,body \
+    --jq "[.[] | select((.mergedAt | fromdateiso8601) > (now - 86400))]" \
+    2>/dev/null || echo "[]")
+
+  echo "$merged" | jq -c '.[]' 2>/dev/null | while IFS= read -r pr; do
+    [ -n "$pr" ] || continue
+    local pr_num pr_title pr_body
+    pr_num=$(echo "$pr" | jq -r '.number')
+    pr_title=$(echo "$pr" | jq -r '.title')
+    pr_body=$(echo "$pr" | jq -r '.body // ""')
+
+    local marker="$STATE_DIR/shipped-$project-pr$pr_num"
+    [ -f "$marker" ] && continue
+
+    # Extract "Fixes/Closes/Resolves #N" issue references from the PR body
+    local issue_nums
+    issue_nums=$(echo "$pr_body" \
+      | grep -oiE '(fix(es)?|close[sd]?|resolve[sd]?) #[0-9]+' \
+      | grep -oE '[0-9]+' || true)
+
+    if [ -n "$issue_nums" ]; then
+      for issue_num in $issue_nums; do
+        local issue_title
+        issue_title=$(gh issue view "$issue_num" --repo "alexsiri7/$project" \
+          --json title -q '.title' 2>/dev/null || echo "")
+        notify "Shipped: $project #$issue_num" \
+          "$issue_title — deployed to prod via PR #$pr_num" \
+          default rocket
+        log "$project: shipped-ntfy for issue #$issue_num via PR #$pr_num"
+      done
+    else
+      notify "Shipped: $project PR #$pr_num" \
+        "$pr_title — deployed to prod" \
+        default rocket
+      log "$project: shipped-ntfy for PR #$pr_num (no linked issue)"
+    fi
+
+    touch "$marker"
+  done
+}
+
+# ----------------------------------------------------------------------------
 log "=== pipeline health check ==="
 for project in "${REPOS[@]}"; do
   check_main_ci "$project"
   check_prod_deploy "$project"
+  check_pr_ci_retry "$project"
+  check_deploy_http "$project"
+  check_shipped_prs "$project"
 done
 reconcile_zombies
 check_disk

--- a/ops/cron/sweep-audits.sh
+++ b/ops/cron/sweep-audits.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# sweep-audits.sh — nightly codebase sweep, rotating through audit workflows.
+#
+# Runs one archon audit workflow per night on one project, cycling through:
+#   4 repos × 3 sweep types = 12-day rotation (keyed off day-of-year).
+#
+# Night 1:  filmduel         — architect
+# Night 2:  word-coach-annie — architect
+# Night 3:  reli             — architect
+# Night 4:  cosmic-match     — architect
+# Night 5:  filmduel         — security
+# Night 6:  word-coach-annie — security
+# Night 7:  reli             — security
+# Night 8:  cosmic-match     — security
+# Night 9:  filmduel         — test-audit
+# Night 10: word-coach-annie — test-audit
+# Night 11: reli             — test-audit
+# Night 12: cosmic-match     — test-audit
+# (cycle repeats)
+#
+# Ported from archon/scripts/poll-sweep.sh. Matches the style of the other
+# ops/cron scripts (log/notify helpers, SECRETS_FILE, SCRIPT_DIR, STATE_DIR).
+#
+# Crontab:
+#   0 2 * * * <repo>/ops/cron/sweep-audits.sh >> /tmp/sweep-audits.log 2>&1
+
+set -uo pipefail
+
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="/mnt/ext-fast"
+STATE_DIR="$HOME/.archon/sweep-state"
+LOG_DIR="$HOME/.archon/logs/sweep"
+CLAUDE_ACCOUNTS="${CLAUDE_ACCOUNTS:-$HOME/.claude:$HOME/.claude-secondary}"
+
+# NTFY_TOPIC loaded from secrets.env. Fail loud if unset.
+SECRETS_FILE="${ARCHON_CRON_SECRETS:-$HOME/.config/archon-cron/secrets.env}"
+# shellcheck source=/dev/null
+[ -r "$SECRETS_FILE" ] && . "$SECRETS_FILE"
+: "${NTFY_TOPIC:?NTFY_TOPIC not set — populate $SECRETS_FILE}"
+LOG_PREFIX="[sweep-audits]"
+
+export ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1
+
+mkdir -p "$STATE_DIR" "$LOG_DIR"
+
+log() { echo "$(date -Is) $LOG_PREFIX $*"; }
+
+notify() {
+  local title="$1" msg="$2" priority="${3:-default}" tags="${4:-robot}"
+  curl -s -o /dev/null \
+    -H "Title: $title" -H "Priority: $priority" -H "Tags: $tags" \
+    -d "$msg" "ntfy.sh/$NTFY_TOPIC" 2>/dev/null || true
+}
+
+# Rotation config. Deliberately hardcoded (not loaded from archon-projects.txt):
+# the 12-slot rotation depends on exactly 4 repos × 3 sweep types. Projects
+# without substantial codebases to audit (un-reminder, interstellarai.net
+# landing page) are intentionally excluded.
+REPOS=(
+  "alexsiri7/filmduel"
+  "alexsiri7/word-coach-annie"
+  "alexsiri7/reli"
+  "alexsiri7/cosmic-match"
+)
+
+SWEEPS=(
+  "archon-architect|Analyze the codebase architecture — identify complexity hotspots, unnecessary abstractions, and opportunities for simplification"
+  "archon-security-audit|Perform a deep security and privacy audit of the entire codebase — check OWASP top 10, auth, data privacy, dependencies, and business logic"
+  "archon-test-audit|Audit test coverage and stability — fix flaky tests, add tests for critical uncovered code paths, improve test quality"
+)
+
+# 4 repos × 3 sweeps = 12-day cycle, keyed off day-of-year.
+day_of_year=$(date +%j)
+slot=$(( (10#$day_of_year - 1) % 12 ))
+
+sweep_idx=$(( slot / 4 ))
+repo_idx=$(( slot % 4 ))
+
+repo="${REPOS[$repo_idx]}"
+repo_name=$(basename "$repo")
+sweep_entry="${SWEEPS[$sweep_idx]}"
+workflow="${sweep_entry%%|*}"
+prompt="${sweep_entry#*|}"
+sweep_name="${workflow#archon-}"
+
+log "=== nightly sweep: $sweep_name on $repo_name (slot $slot of 12) ==="
+
+# Skip if a sweep is already running for this repo (lock TTL: 2h)
+lock_file="$STATE_DIR/${repo_name}.lock"
+if [ -f "$lock_file" ]; then
+  lock_age=$(( $(date +%s) - $(stat -c %Y "$lock_file") ))
+  if [ "$lock_age" -lt 7200 ]; then
+    log "$repo_name: sweep still running (${lock_age}s), skipping"
+    exit 0
+  else
+    log "$repo_name: stale lock (${lock_age}s), removing"
+    rm -f "$lock_file"
+  fi
+fi
+
+# Find local clone
+local_path=""
+for candidate in \
+  "$HOME/.archon/workspaces/${repo}/source" \
+  "$BASE_DIR/$repo_name" \
+  "$HOME/$repo_name"; do
+  if [ -d "$candidate/.git" ]; then
+    local_path="$candidate"
+    break
+  fi
+done
+
+if [ -z "$local_path" ]; then
+  log "ERROR: no local clone found for $repo"
+  notify "Sweep: $repo_name" "No local clone found" high warning
+  exit 1
+fi
+
+# Alternate Claude accounts per slot
+IFS=':' read -ra accounts <<< "$CLAUDE_ACCOUNTS"
+account_dir="${accounts[$((slot % ${#accounts[@]}))]}"
+export CLAUDE_CONFIG_DIR="$account_dir"
+
+log "repo: $local_path"
+log "workflow: $workflow"
+log "account: $(basename "$account_dir")"
+touch "$lock_file"
+
+logfile="$LOG_DIR/${repo_name}-${sweep_name}-$(date +%Y%m%d).log"
+
+cd "$local_path"
+if CLAUDECODE=0 archon workflow run "$workflow" "$prompt" > "$logfile" 2>&1; then
+  log "$repo_name: $sweep_name sweep complete"
+  notify "Sweep done: $repo_name" "$sweep_name complete — check for PR" default mag
+else
+  log "$repo_name: $sweep_name sweep failed (see $logfile)"
+  notify "Sweep failed: $repo_name" "$sweep_name failed — check $logfile" high x
+fi
+
+rm -f "$lock_file"
+log "=== nightly sweep complete ==="


### PR DESCRIPTION
## Summary

Port the unique bits of the parallel pipeline at `/mnt/ext-fast/archon/scripts/` into `ops/cron/` so that directory is retire-able. Nothing outside `ops/cron/` is touched.

### `pipeline-health-cron.sh` — three new per-project checks

- **`check_pr_ci_retry`** (ports `poll-health.sh` check 1): open `archon/*` PRs with `FAILURE` in their status-check rollup get fixed by `archon-assist`. Dedup via `prciretry-<project>-pr<n>` markers in `$STATE_DIR`; markers are cleared automatically when a PR drops out of the failed list (merged, closed, or recovered).
- **`check_deploy_http`** (ports `poll-health.sh` check 3): HTTP-probes each project's `DEPLOY_URLS` entry; if the response is <200 or >=400, files a `bug` issue for the normal pickup cron to dispatch. Dedup via `deploy-down-<project>` marker, cleared on recovery.
- **`check_shipped_prs`** (ports `poll-health.sh` check 4): for projects whose deploy URL is currently healthy, emits `Shipped: <project> #<issue>` ntfys for PRs merged in the last 24h (one ntfy per linked `Fixes/Closes/Resolves #N` issue, or one for the PR itself). Dedup via `shipped-<project>-pr<n>` marker.

`DEPLOY_URLS` is an inline associative array. Entries:

| project | URL | source |
|---|---|---|
| `filmduel` | `https://filmduel.up.railway.app` | from task brief + source script |
| `word-coach-annie` | `https://annie.interstellarai.net/api/health` | `word-coach-annie/.github/workflows/uptime.yml` |
| `reli` | `https://reli.interstellarai.net` | landing-page portfolio card |
| `interstellarai.net` | `https://www.interstellarai.net` | Cloudflare Pages — apex redirects, `www` serves 200 |

`un-reminder` and `cosmic-match` are APK-only (no public HTTP signal) so they're intentionally skipped. Projects without a `DEPLOY_URLS` entry are skipped silently by both `check_deploy_http` and `check_shipped_prs`.

Reuses existing `log` / `notify` / `$STATE_DIR` / `SECRETS_FILE` / `SCRIPT_DIR` helpers — no duplication.

### `sweep-audits.sh` (new)

Faithful port of `archon/scripts/poll-sweep.sh`. Rotating codebase audit: 4 repos × 3 sweep types = 12-slot day-of-year rotation (filmduel / word-coach-annie / reli / cosmic-match × architect / security-audit / test-audit). Uses the ops/cron style (`log`/`notify`, `SECRETS_FILE`, `LOG_PREFIX`, `CLAUDECODE=0`). Rotation is hardcoded and deliberately does **not** load from `archon-projects.txt` — the math depends on exactly 4 codebases with substantial code to audit.

### crontab + README

- `crontab`: add `0 2 * * * ... sweep-audits.sh` (matches `~/.config/systemd/user/archon-sweep.timer`, which fires at `*-*-* 02:00:00`).
- `README.md`: new `sweep-audits.sh` row; pipeline-health row expanded to mention PR-CI retry, deploy-HTTP health, and shipped-PR ntfys.

## Test plan

- [ ] `bash -n ops/cron/pipeline-health-cron.sh` clean (verified locally)
- [ ] `bash -n ops/cron/sweep-audits.sh` clean (verified locally)
- [ ] `chmod +x` set on `ops/cron/sweep-audits.sh` (verified locally — 0755)
- [ ] Dry-run `pipeline-health-cron.sh` on-box with secrets loaded; confirm:
  - [ ] `check_pr_ci_retry` prints "skipping" or "firing" per archon PR
  - [ ] `check_deploy_http` logs `deploy OK (HTTP 200 at …)` for each of the four entries
  - [ ] `check_shipped_prs` emits at most one `shipped-ntfy` per merged PR in last 24h
  - [ ] Markers land in `~/.archon/pipeline-health-state/` with expected prefixes (`prciretry-`, `deploy-down-`, `shipped-`) and are cleared when conditions clear
- [ ] Dry-run `sweep-audits.sh` on-box; confirm slot math + lock-file behavior
- [ ] Install updated crontab (`crontab ops/cron/crontab`); confirm `0 2 * * * ... sweep-audits.sh` row is present
- [ ] After one 02:00 tick, `/tmp/sweep-audits.log` shows the expected repo/sweep combo for the current day-of-year slot

## Notes / follow-ups for the user

- Source files at `/mnt/ext-fast/archon/scripts/poll-health.sh` and `poll-sweep.sh` are **not** deleted in this PR — separate cleanup.
- `check_prod_deploy` (existing) and the new `check_deploy_http` are complementary: the former uses GH Actions / Deployments API signals; the latter is a black-box HTTP probe. Both coexist — no de-duplication attempted since they catch different failure modes (e.g. Cloudflare edge down but deploy "succeeded").

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)