### PR TITLE
feat: add lachesis to pipeline-health-cron DEPLOY_URLS

### DIFF
--- a/ops/cron/pipeline-health-cron.sh
+++ b/ops/cron/pipeline-health-cron.sh
@@ -45,6 +45,7 @@ declare -A DEPLOY_URLS=(
   ["word-coach-annie"]="https://annie.interstellarai.net/api/health"
   ["reli"]="https://reli.interstellarai.net"
   ["interstellarai.net"]="https://www.interstellarai.net"
+  ["lachesis"]="https://lachesis.interstellarai.net/healthz"
 )
 
 declare -A GITHUB_PROJECTS=(


### PR DESCRIPTION
## Summary

Add Lachesis prod deployment to the pipeline-health-cron monitor's DEPLOY_URLS map. This enables health monitoring of the Lachesis service, ensuring deployment regressions are detected within 30 minutes.

## Changes

- **File**: `ops/cron/pipeline-health-cron.sh`
- **Change**: Added `["lachesis"]="https://lachesis.interstellarai.net/healthz"` to the DEPLOY_URLS map (lines 43-48)
- **Motivation**: Complete the Lachesis staging deployment feature (issue #35, requirement 017) by adding Lachesis prod to the portfolio's health-check monitoring suite alongside filmduel, word-coach-annie, reli, and the main website

## Context

This change is part of establishing a full staging deployment for Lachesis (issue #35):
- **Tasks 1-6**: Infrastructure-only (Railway, Supabase, Cloudflare DNS, Google OAuth) — completed manually
- **Task 7**: Code change — add lachesis to health monitoring (this PR)

The staging deployment mirrors prod configuration and validates changes before prod deployment, aligning with requirement 017 (every project has a staging environment).

## Validation

- ✅ Bash syntax check: `bash -n ops/cron/pipeline-health-cron.sh` passes (exits 0, no errors)
- ✅ No TypeScript, lint, format, or test scripts in this project
- ⚠️ Astro build skipped: pre-existing Node.js version constraint (unrelated to this change)

## Notes

- The change uses the prod URL (`https://lachesis.interstellarai.net/healthz`) per Lachesis healthcheck design (railway.toml defines `/healthz` endpoint)
- Staging deployment (infrastructure) and prod health monitoring (this code change) work together to satisfy issue #35
- Per ADR-005, staging secrets are isolated from prod; health monitor covers prod only

Fixes #35