### PR TITLE
Fix: add Reli schema isolation and backup

### DIFF
--- a/ops/cron/backup-dbs.sh
+++ b/ops/cron/backup-dbs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Backup Annie, Reli (Supabase PostgreSQL → SQLite), FilmDuel, Kindred, Lachesis (pg_dump)
+# Backup Annie (Supabase PostgreSQL → SQLite), Reli, FilmDuel, Kindred, Lachesis (pg_dump)
 # - Local: /mnt/steam-slow/backups/ (7-day rotation)
 # - Remote: Google Drive via rclone (if configured)
 
@@ -42,17 +42,20 @@ else
     log "ERROR: Annie Supabase export failed"
 fi
 
-# --- Reli (Supabase PostgreSQL → SQLite export) ---
+# --- Reli (Supabase PostgreSQL → pg_dump, schema-scoped) ---
 RELI_BACKUP_DIR="$BACKUP_ROOT/reli"
 mkdir -p "$RELI_BACKUP_DIR"
 
-RELI_OUT="$RELI_BACKUP_DIR/reli-${TIMESTAMP}.db"
-if cd "$ANNIE_PROJECT_DIR" && DATABASE_URL="$RELI_DB_URL" node scripts/export-to-sqlite.mjs "$RELI_OUT" 2>&1; then
+RELI_OUT="$RELI_BACKUP_DIR/reli-${TIMESTAMP}.sql.gz"
+if pg_dump "$RELI_DB_URL" --no-owner --no-acl --schema=reli 2>&1 | gzip > "$RELI_OUT"; then
     SIZE=$(du -h "$RELI_OUT" | cut -f1)
-    THINGS=$(sqlite3 "$RELI_OUT" "SELECT count(*) FROM things" 2>/dev/null || echo "?")
+    THINGS=$(psql "$RELI_DB_URL" -t -c "SELECT count(*) FROM reli.things" 2>/dev/null | tr -d ' ' || echo "?")
     log "Reli backed up: $RELI_OUT ($SIZE, $THINGS things)"
+    if [ "$THINGS" = "0" ] || [ "$THINGS" = "?" ]; then
+        log "WARNING: Reli backup has 0 or unknown things — possible data loss or schema not yet migrated!"
+    fi
 else
-    log "ERROR: Reli Supabase export failed"
+    log "ERROR: Reli pg_dump failed"
 fi
 
 # --- FilmDuel (Supabase PostgreSQL → pg_dump) ---
@@ -106,7 +109,7 @@ fi
 # --- Rotate old backups ---
 find "$ANNIE_BACKUP_DIR" -name "*.db" -mtime +$KEEP_DAYS -delete 2>/dev/null && \
     log "Rotated Annie backups older than ${KEEP_DAYS} days" || true
-find "$RELI_BACKUP_DIR" -name "*.db" -mtime +$KEEP_DAYS -delete 2>/dev/null && \
+find "$RELI_BACKUP_DIR" -name "*.sql.gz" -mtime +$KEEP_DAYS -delete 2>/dev/null && \
     log "Rotated Reli backups older than ${KEEP_DAYS} days" || true
 find "$FILMDUEL_BACKUP_DIR" -name "*.sql.gz" -mtime +$KEEP_DAYS -delete 2>/dev/null && \
     log "Rotated FilmDuel backups older than ${KEEP_DAYS} days" || true

--- a/ops/db-migrations/017-reli-schema-isolation.sql
+++ b/ops/db-migrations/017-reli-schema-isolation.sql
@@ -1,0 +1,73 @@
+-- =============================================================
+-- 017: Reli schema isolation — PROD DB
+-- Run against: prod Supabase (default / consolidated DB)
+-- Prerequisites: Reli tables must be migrated one-shot first
+-- =============================================================
+
+-- Step 1: Discover existing Reli tables before moving
+-- Run:  \dt public.*
+-- Identify all reli-owned tables and list them below.
+
+-- Step 2: Create reli schema
+CREATE SCHEMA IF NOT EXISTS reli;
+
+-- Step 3: Move tables into reli schema
+-- Repeat for each reli-owned table discovered in Step 1.
+-- Run all moves inside a single transaction to avoid FK issues:
+--
+-- BEGIN;
+-- ALTER TABLE public.{table1} SET SCHEMA reli;
+-- ALTER TABLE public.{table2} SET SCHEMA reli;
+-- ...
+-- COMMIT;
+
+-- Step 4: Create scoped role
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'reli_app') THEN
+    CREATE ROLE reli_app NOLOGIN;
+  END IF;
+END $$;
+
+GRANT USAGE ON SCHEMA reli TO reli_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA reli TO reli_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA reli TO reli_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA reli
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO reli_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA reli
+  GRANT USAGE, SELECT ON SEQUENCES TO reli_app;
+
+-- Step 5: Assign the app user to the role
+-- Uncomment and adjust for your connection user:
+-- GRANT reli_app TO authenticator;
+-- Or: GRANT reli_app TO {connection_user};
+
+-- Verify: tables now in reli schema
+-- \dt reli.*
+-- SELECT count(*) FROM reli.things;
+
+
+-- =============================================================
+-- 017: Reli schema isolation — STAGING DB
+-- Run against: staging Supabase (consolidated staging instance)
+-- Note: empty schema — no data migration needed
+-- =============================================================
+
+CREATE SCHEMA IF NOT EXISTS reli;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'reli_app') THEN
+    CREATE ROLE reli_app NOLOGIN;
+  END IF;
+END $$;
+
+GRANT USAGE ON SCHEMA reli TO reli_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA reli
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO reli_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA reli
+  GRANT USAGE, SELECT ON SEQUENCES TO reli_app;
+
+-- Connection string note:
+-- After running this migration, update the Reli app's DATABASE_URL
+-- to include the search_path. Examples:
+--   Prisma:    postgresql://user:pass@host:5432/postgres?schema=reli
+--   Direct:    postgresql://user:pass@host:5432/postgres?options=-csearch_path%3Dreli

--- a/requirements/013-migrate-reli-to-consolidated-db.md
+++ b/requirements/013-migrate-reli-to-consolidated-db.md
@@ -2,7 +2,7 @@
 created: '2026-05-15'
 github_issue: 27
 id: '013'
-status: idea
+status: in-progress
 title: Migrate Reli to consolidated DB
 updated: '2026-05-15'
 ---


### PR DESCRIPTION
## Summary
Migrate Reli to the consolidated database by creating the `reli` schema and scoped `reli_app` role in both prod and staging instances, mirroring the pattern established for Kindred (#15) and Lachesis (#16).

## Changes
- **ops/db-migrations/017-reli-schema-isolation.sql** (created): Dual-section SQL runbook for provisioning `reli` schema and role with full GRANT chain and table-move scaffolding in PROD, and empty schema setup in STAGING
- **ops/cron/backup-dbs.sh** (updated): Replace Reli's SQLite export with schema-scoped `pg_dump --schema=reli` and `.sql.gz` rotation, matching Kindred/Lachesis backup pattern
- **requirements/013-migrate-reli-to-consolidated-db.md** (updated): Changed status from `idea` to `in-progress`

## Validation
All checks passed:
- ✅ Bash syntax validation (`bash -n ops/cron/backup-dbs.sh`)
- ✅ SQL structure: PROD section with schema, role, grants, and table-move scaffold
- ✅ Staging section: empty schema with role and grants  
- ✅ Backup uses `pg_dump --schema=reli` with qualified `reli.things` count
- ✅ No old SQLite export code remains
- ✅ Rotation uses `.sql.gz` glob pattern
- ✅ Build passes: 14 pages built (no regressions)

## Scope
This PR sets up infrastructure for the migration; actual data movement (dump/restore from standalone DB to consolidated instance, update DATABASE_URL in Railway, decommission old standalone DB) are manual operator steps documented in the SQL file.

Fixes #27