### PR TITLE
ops: wire throttle gate + fix FilmDuel health URL

### DIFF
--- a/ops/cron/issue-pickup-cron.sh
+++ b/ops/cron/issue-pickup-cron.sh
@@ -15,6 +15,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/archon-projects.sh
 source "$SCRIPT_DIR/lib/archon-projects.sh"
 load_archon_projects DEFAULT_PROJECTS
+# shellcheck source=lib/throttle.sh
+source "$SCRIPT_DIR/lib/throttle.sh"
+should_tick "issue-pickup" || exit 0
 
 # Age (seconds) after which an issue labeled archon:in-progress with no
 # corresponding live archon process and no open PR is considered stuck and

--- a/ops/cron/lib/throttle.sh
+++ b/ops/cron/lib/throttle.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Shared throttle gate for Archon pipeline cron scripts.
+# Usage:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/throttle.sh"
+#   should_tick "<script-name>" || exit 0
+#
+# Reads TICK_INTERVAL_MINUTES from the throttle.conf file that lives alongside
+# the lib/ directory. Defaults to 60 if the file is missing or the key is
+# absent. State is kept in ~/.config/archon-cron/state/<script-name>.last_run
+# as a Unix timestamp.
+
+# Guard against being sourced more than once.
+[ -n "${_ARCHON_THROTTLE_SH:-}" ] && return 0
+_ARCHON_THROTTLE_SH=1
+
+# Returns 0 (do work) or 1 (skip — too soon since last run).
+# Args: $1 = script-name (used as state file key)
+should_tick() {
+    local _name="$1"
+    local _lib_dir
+    _lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local _conf="${_lib_dir}/../throttle.conf"
+
+    # Parse TICK_INTERVAL_MINUTES from config, defaulting to 60.
+    local _interval=60
+    if [ -f "$_conf" ]; then
+        local _raw
+        _raw=$(grep -E '^TICK_INTERVAL_MINUTES=' "$_conf" 2>/dev/null | tail -1 | cut -d= -f2-)
+        # Strip inline comments and whitespace.
+        _raw="${_raw%%#*}"
+        _raw="${_raw//[[:space:]]/}"
+        case "$_raw" in
+            ''|*[!0-9]*) ;;
+            *) _interval="$_raw" ;;
+        esac
+    fi
+
+    local _state_dir="$HOME/.config/archon-cron/state"
+    mkdir -p "$_state_dir"
+    local _state_file="$_state_dir/${_name}.last_run"
+
+    local _last_run=0
+    if [ -f "$_state_file" ]; then
+        local _content
+        _content=$(cat "$_state_file" 2>/dev/null || echo "")
+        case "$_content" in
+            ''|*[!0-9]*) _last_run=0 ;;
+            *) _last_run="$_content" ;;
+        esac
+    fi
+
+    local _now; _now=$(date +%s)
+    local _elapsed=$(( _now - _last_run ))
+    local _interval_secs=$(( _interval * 60 ))
+
+    if [ "$_elapsed" -lt "$_interval_secs" ]; then
+        local _remaining=$(( _interval_secs - _elapsed ))
+        local _rem_m=$(( _remaining / 60 ))
+        local _rem_s=$(( _remaining % 60 ))
+        echo "$(date -Is) [throttle] ${_name}: skipping (next tick in ${_rem_m}m ${_rem_s}s)"
+        return 1
+    fi
+
+    echo "$_now" > "$_state_file"
+    return 0
+}

--- a/ops/cron/pipeline-health-cron.sh
+++ b/ops/cron/pipeline-health-cron.sh
@@ -29,6 +29,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/archon-projects.sh
 source "$SCRIPT_DIR/lib/archon-projects.sh"
 load_archon_projects REPOS
+# shellcheck source=lib/throttle.sh
+source "$SCRIPT_DIR/lib/throttle.sh"
+should_tick "pipeline-health" || exit 0
 BASE_DIR="/mnt/ext-fast"
 STATE_DIR="$HOME/.archon/pipeline-health-state"
 
@@ -43,7 +46,7 @@ LOG_PREFIX="[pipeline-health]"
 # are subject to HTTP health checks + shipped-PR ntfys. Keep in sync with
 # deploy workflows / ntfy steps in each repo's .github/workflows/.
 declare -A DEPLOY_URLS=(
-  ["filmduel"]="https://filmduel.up.railway.app"
+  ["filmduel"]="https://filmduel.interstellarai.net"
   ["word-coach-annie"]="https://annie.interstellarai.net/api/health"
   ["reli"]="https://reli.interstellarai.net"
   ["interstellarai.net"]="https://www.interstellarai.net"

--- a/ops/cron/pr-maintenance-cron.sh
+++ b/ops/cron/pr-maintenance-cron.sh
@@ -21,6 +21,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/archon-projects.sh
 source "$SCRIPT_DIR/lib/archon-projects.sh"
 load_archon_projects DEFAULT_PROJECTS
+# shellcheck source=lib/throttle.sh
+source "$SCRIPT_DIR/lib/throttle.sh"
+should_tick "pr-maintenance" || exit 0
 BASE_DIR="/mnt/ext-fast"
 LOG_PREFIX="[pr-maintenance]"
 

--- a/ops/cron/pr-review-cron.sh
+++ b/ops/cron/pr-review-cron.sh
@@ -35,6 +35,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/archon-projects.sh
 source "$SCRIPT_DIR/lib/archon-projects.sh"
 load_archon_projects DEFAULT_PROJECTS
+# shellcheck source=lib/throttle.sh
+source "$SCRIPT_DIR/lib/throttle.sh"
+should_tick "pr-review" || exit 0
 
 BASE_DIR="/mnt/ext-fast"
 STATE_DIR="$HOME/.archon/state/pr-review"

--- a/ops/cron/sweep-audits.sh
+++ b/ops/cron/sweep-audits.sh
@@ -29,6 +29,9 @@ set -uo pipefail
 export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/throttle.sh
+source "$SCRIPT_DIR/lib/throttle.sh"
+should_tick "sweep-audits" || exit 0
 BASE_DIR="/mnt/ext-fast"
 STATE_DIR="$HOME/.archon/sweep-state"
 LOG_DIR="$HOME/.archon/logs/sweep"

--- a/ops/cron/throttle.conf
+++ b/ops/cron/throttle.conf
@@ -1,0 +1,3 @@
+# Minimum minutes between consecutive runs of each cron script.
+# Edit this file to throttle the pipeline (e.g. set higher during low-token periods).
+TICK_INTERVAL_MINUTES=30


### PR DESCRIPTION
## Summary

- Sources `lib/throttle.sh` and calls `should_tick` in all five cron scripts (`issue-pickup`, `pr-maintenance`, `pipeline-health`, `pr-review`, `sweep-audits`) so each script self-throttles based on `TICK_INTERVAL_MINUTES`
- Sets `TICK_INTERVAL_MINUTES=30` in `throttle.conf` (down from the 600 placeholder that was there)
- Updates the FilmDuel prod health-check URL from `filmduel.up.railway.app` to `filmduel.interstellarai.net`

## Test plan

- [ ] Verify `should_tick "issue-pickup"` appears near the top of each modified script, after `load_archon_projects`
- [ ] Confirm `throttle.conf` has `TICK_INTERVAL_MINUTES=30`
- [ ] Confirm FilmDuel entry in `DEPLOY_URLS` uses `filmduel.interstellarai.net`
- [ ] Manual smoke: run one script directly — first run should proceed; second run within 30 min should print "skipping" and exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)