### PR TITLE
fix(throttle): add warning logs for silent failures + bats tests

### DIFF
--- a/ops/cron/lib/throttle.sh
+++ b/ops/cron/lib/throttle.sh
@@ -31,13 +31,18 @@ should_tick() {
         _raw="${_raw%%#*}"
         _raw="${_raw//[[:space:]]/}"
         case "$_raw" in
-            ''|*[!0-9]*) ;;
+            '') ;;
+            *[!0-9]*)
+                echo "$(date -Is) [throttle] ${_name}: WARNING — invalid TICK_INTERVAL_MINUTES='$_raw', using default ${_interval}m" >&2
+                ;;
             *) _interval="$_raw" ;;
         esac
     fi
 
     local _state_dir="$HOME/.config/archon-cron/state"
-    mkdir -p "$_state_dir"
+    if ! mkdir -p "$_state_dir" 2>/dev/null; then
+        echo "$(date -Is) [throttle] ${_name}: WARNING — cannot create state dir $_state_dir, throttle disabled" >&2
+    fi
     local _state_file="$_state_dir/${_name}.last_run"
 
     local _last_run=0
@@ -45,7 +50,11 @@ should_tick() {
         local _content
         _content=$(cat "$_state_file" 2>/dev/null || echo "")
         case "$_content" in
-            ''|*[!0-9]*) _last_run=0 ;;
+            '') _last_run=0 ;;
+            *[!0-9]*)
+                echo "$(date -Is) [throttle] ${_name}: WARNING — corrupt state file, resetting" >&2
+                _last_run=0
+                ;;
             *) _last_run="$_content" ;;
         esac
     fi
@@ -62,6 +71,8 @@ should_tick() {
         return 1
     fi
 
-    echo "$_now" > "$_state_file"
+    if ! echo "$_now" > "$_state_file" 2>/dev/null; then
+        echo "$(date -Is) [throttle] ${_name}: WARNING — cannot write state file $_state_file, next run will not be throttled" >&2
+    fi
     return 0
 }

--- a/ops/cron/tests/throttle.bats
+++ b/ops/cron/tests/throttle.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+# Unit tests for ops/cron/lib/throttle.sh
+#
+# Run: bats ops/cron/tests/throttle.bats
+
+setup() {
+    # Use a temp HOME so state files don't pollute the real one.
+    export HOME="$BATS_TMPDIR/home-$$"
+    mkdir -p "$HOME"
+
+    # Unset the source guard so each test gets a fresh load.
+    unset _ARCHON_THROTTLE_SH
+
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    source "$SCRIPT_DIR/lib/throttle.sh"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/home-$$"
+}
+
+# ── First-run behaviour ──────────────────────────────────────────────
+
+@test "should_tick returns 0 on first run (no state file)" {
+    run should_tick "test-script"
+    [ "$status" -eq 0 ]
+    [ -f "$HOME/.config/archon-cron/state/test-script.last_run" ]
+}
+
+@test "state file contains a numeric timestamp after first tick" {
+    should_tick "test-script"
+    local content
+    content=$(cat "$HOME/.config/archon-cron/state/test-script.last_run")
+    [[ "$content" =~ ^[0-9]+$ ]]
+}
+
+# ── Throttle behaviour ───────────────────────────────────────────────
+
+@test "should_tick returns 1 when called again within interval" {
+    should_tick "test-script"
+    # Reset source guard so we can call again in same process.
+    unset _ARCHON_THROTTLE_SH
+    source "$SCRIPT_DIR/lib/throttle.sh"
+    run should_tick "test-script"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"skipping"* ]]
+}
+
+@test "should_tick returns 0 when state file timestamp is old enough" {
+    mkdir -p "$HOME/.config/archon-cron/state"
+    # Write a timestamp 2 hours in the past.
+    local old_ts=$(( $(date +%s) - 7200 ))
+    echo "$old_ts" > "$HOME/.config/archon-cron/state/test-script.last_run"
+    run should_tick "test-script"
+    [ "$status" -eq 0 ]
+}
+
+# ── Config parsing ───────────────────────────────────────────────────
+
+@test "should_tick uses default interval (60) when config is missing" {
+    # Temporarily hide the config file.
+    local conf="$SCRIPT_DIR/throttle.conf"
+    local backup="$SCRIPT_DIR/throttle.conf.bak"
+    mv "$conf" "$backup"
+
+    mkdir -p "$HOME/.config/archon-cron/state"
+    # Write timestamp 45 minutes ago — should still be throttled at 60m default.
+    local ts=$(( $(date +%s) - 2700 ))
+    echo "$ts" > "$HOME/.config/archon-cron/state/test-default.last_run"
+
+    unset _ARCHON_THROTTLE_SH
+    source "$SCRIPT_DIR/lib/throttle.sh"
+    run should_tick "test-default"
+    mv "$backup" "$conf"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"skipping"* ]]
+}
+
+# ── Corrupt / invalid state ──────────────────────────────────────────
+
+@test "should_tick handles corrupt state file (treats as never ran)" {
+    mkdir -p "$HOME/.config/archon-cron/state"
+    echo "not-a-number" > "$HOME/.config/archon-cron/state/test-corrupt.last_run"
+    run should_tick "test-corrupt"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARNING"* ]]
+    [[ "$output" == *"corrupt"* ]]
+}
+
+@test "should_tick handles empty state file (treats as never ran)" {
+    mkdir -p "$HOME/.config/archon-cron/state"
+    echo -n "" > "$HOME/.config/archon-cron/state/test-empty.last_run"
+    run should_tick "test-empty"
+    [ "$status" -eq 0 ]
+}
+
+# ── Invalid config values ────────────────────────────────────────────
+
+@test "should_tick warns on non-numeric config value" {
+    local conf="$SCRIPT_DIR/throttle.conf"
+    local backup="$SCRIPT_DIR/throttle.conf.bak"
+    cp "$conf" "$backup"
+    echo "TICK_INTERVAL_MINUTES=abc" > "$conf"
+
+    unset _ARCHON_THROTTLE_SH
+    source "$SCRIPT_DIR/lib/throttle.sh"
+    run should_tick "test-badconf"
+    mv "$backup" "$conf"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARNING"* ]]
+    [[ "$output" == *"invalid TICK_INTERVAL_MINUTES"* ]]
+}
+
+# ── Source guard ─────────────────────────────────────────────────────
+
+@test "source guard prevents double-sourcing" {
+    # _ARCHON_THROTTLE_SH is already set from setup().
+    # Sourcing again should be a no-op (return 0).
+    source "$SCRIPT_DIR/lib/throttle.sh"
+    # If we got here without error, the guard worked.
+    [ -n "$_ARCHON_THROTTLE_SH" ]
+}


### PR DESCRIPTION
## Summary

Follow-up fixes from automated post-merge review of #52:

- **HIGH**: Add 9 `bats` unit tests for `should_tick` covering first run, throttle behavior, config parsing, corrupt state handling, and source guard
- **MEDIUM**: Log warnings when state dir creation or state file write fails — throttle was silently failing open with no indication
- **LOW**: Log warnings for invalid config values and corrupt state files instead of silently falling back to defaults

## Test plan

- [x] All 9 bats tests pass (`bats ops/cron/tests/throttle.bats`)
- [ ] Verify warning messages appear in cron logs when state dir is unwritable
- [ ] Verify throttle still works correctly in normal operation

Review artifacts: see #52 comments for full review details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)