### PR TITLE
Fix: Guard against null SHA/TS from GitHub API in deploy check

### DIFF
--- a/ops/cron/pipeline-health-cron.sh
+++ b/ops/cron/pipeline-health-cron.sh
@@ -377,6 +377,14 @@ check_prod_deploy() {
   head_sha=$(echo "$head_json" | jq -r '.sha')
   head_ts=$(echo "$head_json" | jq -r '.ts')
 
+  # Guard: jq returns the string "null" for missing fields on error responses.
+  # If we got null for either field, the API call failed — skip silently.
+  if [ "$head_sha" = "null" ] || [ -z "$head_sha" ] || \
+     [ "$head_ts" = "null" ] || [ -z "$head_ts" ]; then
+    log "$project: commits/main API returned null SHA/TS — transient failure, skipping"
+    return
+  fi
+
   # --- Source (a): GH Actions deploy workflow ---
   local deploy_sha="" deploy_ts="" deploy_state="" deploy_url=""
   local wf_run


### PR DESCRIPTION
## Summary

- Adds an 8-line null-SHA guard to `check_prod_deploy()` in `ops/cron/pipeline-health-cron.sh`
- Prevents false positive "Prod deploy lagging main" issues when the GitHub commits API returns an error response whose fields `jq -r` resolves to the literal string `"null"`
- Root cause: transient GitHub API error → `jq -r '.sha'` returns string `"null"` → `date -d "null"` fails → `head_epoch=0` → bogus age of ~1.78 billion seconds triggers stale-deploy alarm

## Root Cause Chain (Fixed)

1. Transient GitHub API error → `gh api repos/.../commits/main` returns error JSON
2. `jq -r '.sha'` on error JSON → string `"null"` (not empty, passes `[ -n ]` check) ← **guard added here**
3. `date -d "null" +%s` fails → `head_epoch=0` (from `|| echo 0` fallback)
4. `age = now_epoch - 0 ≈ 1.78 billion` → triggers stale-deploy alarm
5. False issue created

## Test plan

- [ ] Verify `bash -n ops/cron/pipeline-health-cron.sh` passes (syntax check)
- [ ] Confirm no regressions on next cron run (check `/tmp/pipeline-health.log`)
- [ ] Verify no false positive issues filed after merge

Fixes alexsiri7/word-coach-annie#925